### PR TITLE
ODH-ADR-Operator-0004-replica-image-support

### DIFF
--- a/operator/ODH-ADR-Operator-0004-replica-image-support.md
+++ b/operator/ODH-ADR-Operator-0004-replica-image-support.md
@@ -17,36 +17,64 @@ This document explains about upgrading the DSC CRD to support customizing the re
 
 ## Why
 
-Current operator design doesnot support changing the replica count and the images are hard-coded in the manifests. A lot of teams and users have started requesting for providing support of manipulating these fields.
-NOTE: The image update is targeted for dev purposes and will not be available in production. 
+Current operator design does not support changing the replica count and the images are hard-coded in the manifests. A lot of teams and users have started requesting for providing support of manipulating these fields.
+NOTE: The image update is targeted for dev purposes and will not be available in a supported configuration. 
 
 ## Goals
 
-* For each component(eg. codeflare, ray, kserve etc) provide a field `replicas` through which we can modify the the Deployment's replica count. If a component is deploying multiple deplyoments, then something like this is preferred:
+* For each component(eg. codeflare, ray, kserve etc) provide a field `replicas` through which we can modify the the Deployment's replica count. An example yaml is given below:
   ```yaml
     spec:
   components:
      workbenches:
-          notebookController:
-               replicaCount: <>
-          kfNotebookController:
-                replicaCount: <>
+        managementState: Managed
+        notebookController:
+            replicas: 1
+        kfNotebookController:
+            replicas: 1
   ```
 * For each component(eg. codeflare, ray, kserve etc) provide an image field in the *devFlags* through which we can pass-in a custom image to be used by the controller.
-* Certain components uses other images(for eg. datascience-pipelines-controller uses `IMAGE_API_SERVER`, `IMAGES_ARTIFACT`). We need to provide support to customize these images as well in the *devFlags*
-* Control the resource limits and requests for individual components for more fine grained control.
+* Control the resource limits and requests for individual components for more fine grained control. An example yaml is given below:
+  ```yaml
+    spec:
+  components:
+    datasciencepipelines:
+      managementState: Managed
+      data-science-pipelines-operator-controller-manager:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+  ```  
 
 ## Non-Goals
 
 * Convert *devFlags* type to `runtime.RawExtension` to make devFlags flexible. [ref comment](https://github.com/opendatahub-io/architecture-decision-records/pull/23#issuecomment-1847519245)
+* As an incremental goal, we can introduce HPAs(only for Dashboards or services which requires auto scaling).
+  An example yaml is given below:
+  ```yaml
+    spec:
+  components:
+    dashboard:
+      managementState: Managed
+      dashboard:
+        autoscale:
+          hpa:
+            minReplicas: 1
+            maxReplicas: 10
+  ```   
+  
 ## How
 
 The idea is to create a custom plugin for the kustomize where we use JSON patch to patch these updated values and then deploy the manifests.
 
 ## Open Questions
 
-- Should we limit the max replica count to 2 in case of controllers?
-- As per current requests, only Dashboard team require HPAs. So as an initial step should we start using HPAs only for Dashboard. As for other teams, we can(maybe for now) add replica count in the devFlags and then move it to the *base* when required?
+- Should we limit the max replica count to 2 in case of controllers? (Answer)[https://github.com/opendatahub-io/architecture-decision-records/pull/23#issuecomment-1883820075]
+- As per current requests, only Dashboard team require HPAs. So as an initial step should we start using HPAs only for Dashboard. As for other teams, we can(maybe for now) add replica count in the devFlags and then move it to the *base* when required? Answer: HPA can be implemented as an incremental update.
 
 ## Alternatives
 

--- a/operator/ODH-ADR-Operator-0004-replica-image-support.md
+++ b/operator/ODH-ADR-Operator-0004-replica-image-support.md
@@ -17,7 +17,7 @@ This document explains about upgrading the DSC CRD to support customizing the re
 
 ## Why
 
-Current operator design does not support changing the replica count, images are hard-coded in the manifests and the is no way to set the resource limits/requests. A lot of teams and users have started requesting for providing support of manipulating these fields.
+Current operator design does not support changing the replica count, images are hard-coded in the manifests and there is no way to set the resource limits/requests. A lot of teams and users have started requesting for providing support of manipulating these fields.
 NOTE: The image update is targeted for dev purposes and will not be available in a supported configuration. 
 
 ## Goals
@@ -33,7 +33,21 @@ NOTE: The image update is targeted for dev purposes and will not be available in
         kfNotebookController:
             replicas: 1
   ```
-* For each component(eg. codeflare, ray, kserve etc) provide an image(s) field in the *devFlags* through which we can pass-in a custom image(s) to be used by the controller.
+* For each component(eg. codeflare, ray, kserve etc) provide an image(s) field in the *devFlags* through which we can pass-in a custom image(s) to be used by the controller. Example yaml is given below:
+  ```yaml
+    spec:
+  components:
+     workbenches:
+        managementState: Managed
+        notebookController:
+            replicas: 1
+        kfNotebookController:
+            replicas: 1
+        devFlags:
+          images:
+            odh-notebook-controller-image: quay.io/opendatahub/odh-notebook-controller:latest
+            kf-notebook-controller-image: quay.io/opendatahub/kubeflow-notebook-controller:latest
+  ```
 * Control the resource limits and requests for individual components for more fine grained control. An example yaml is given below:
   ```yaml
     spec:

--- a/operator/ODH-ADR-Operator-0004-replica-image-support.md
+++ b/operator/ODH-ADR-Operator-0004-replica-image-support.md
@@ -14,28 +14,39 @@
 ## What
 
 This document explains about upgrading the DSC CRD to support customizing the replica count, images and modifying the resource limits/requests of individual components.
+
 ## Why
 
-Current operator design doesnot support changing the replica count and the images are hard-coded in the manifests. A lot of teams and users have started requesting for providing support of manipulating these fields. 
+Current operator design doesnot support changing the replica count and the images are hard-coded in the manifests. A lot of teams and users have started requesting for providing support of manipulating these fields.
+NOTE: The image update is targeted for dev purposes and will not be available in production. 
 
 ## Goals
 
-* For each component(eg. codeflare, ray, kserve etc) provide a field `replicas` through which we can modify the the Deployment's replica count.
-* For each component(eg. codeflare, ray, kserve etc) provide an image field through which we can pass-in a custom image to be used by the controller.
-* Certain components uses other images(for eg. datascience-pipelines-controller uses `IMAGE_API_SERVER`, `IMAGES_ARTIFACT`). We need to provide support to customize these images as well.
+* For each component(eg. codeflare, ray, kserve etc) provide a field `replicas` through which we can modify the the Deployment's replica count. If a component is deploying multiple deplyoments, then something like this is preferred:
+  ```yaml
+    spec:
+  components:
+     workbenches:
+          notebookController:
+               replicaCount: <>
+          kfNotebookController:
+                replicaCount: <>
+  ```
+* For each component(eg. codeflare, ray, kserve etc) provide an image field in the *devFlags* through which we can pass-in a custom image to be used by the controller.
+* Certain components uses other images(for eg. datascience-pipelines-controller uses `IMAGE_API_SERVER`, `IMAGES_ARTIFACT`). We need to provide support to customize these images as well in the *devFlags*
 * Control the resource limits and requests for individual components for more fine grained control.
 
 ## Non-Goals
 
-* 
+* Convert *devFlags* type to `runtime.RawExtension` to make devFlags flexible. [ref comment](https://github.com/opendatahub-io/architecture-decision-records/pull/23#issuecomment-1847519245)
 ## How
 
 The idea is to create a custom plugin for the kustomize where we use JSON patch to patch these updated values and then deploy the manifests.
 
 ## Open Questions
 
-- What is the best way to implement this? Should we fetch the Deployment, read the env array, apply the changes then patch the changes.
-- The requirement suggests to update the images in env, in this case JSON patch doesnot support selecting maps in an array using the key value. It allows us to select only using the array index(here env being the array). Will the env always have the same ordering of its values? If we choose the array index method, it is pretty fragile. Either some sort of strategic merge or implementing own 'plugin'?
+- Should we limit the max replica count to 2 in case of controllers?
+- As per current requests, only Dashboard team require HPAs. So as an initial step should we start using HPAs only for Dashboard. As for other teams, we can(maybe for now) add replica count in the devFlags and then move it to the *base* when required?
 
 ## Alternatives
 

--- a/operator/ODH-ADR-Operator-0004-replica-image-support.md
+++ b/operator/ODH-ADR-Operator-0004-replica-image-support.md
@@ -17,7 +17,7 @@ This document explains about upgrading the DSC CRD to support customizing the re
 
 ## Why
 
-Current operator design does not support changing the replica count and the images are hard-coded in the manifests. A lot of teams and users have started requesting for providing support of manipulating these fields.
+Current operator design does not support changing the replica count, images are hard-coded in the manifests and the is no way to set the resource limits/requests. A lot of teams and users have started requesting for providing support of manipulating these fields.
 NOTE: The image update is targeted for dev purposes and will not be available in a supported configuration. 
 
 ## Goals
@@ -33,7 +33,7 @@ NOTE: The image update is targeted for dev purposes and will not be available in
         kfNotebookController:
             replicas: 1
   ```
-* For each component(eg. codeflare, ray, kserve etc) provide an image field in the *devFlags* through which we can pass-in a custom image to be used by the controller.
+* For each component(eg. codeflare, ray, kserve etc) provide an image(s) field in the *devFlags* through which we can pass-in a custom image(s) to be used by the controller.
 * Control the resource limits and requests for individual components for more fine grained control. An example yaml is given below:
   ```yaml
     spec:
@@ -72,9 +72,6 @@ NOTE: The image update is targeted for dev purposes and will not be available in
 The idea is to create a custom plugin for the kustomize where we use JSON patch to patch these updated values and then deploy the manifests.
 
 ## Open Questions
-
-- Should we limit the max replica count to 2 in case of controllers? (Answer)[https://github.com/opendatahub-io/architecture-decision-records/pull/23#issuecomment-1883820075]
-- As per current requests, only Dashboard team require HPAs. So as an initial step should we start using HPAs only for Dashboard. As for other teams, we can(maybe for now) add replica count in the devFlags and then move it to the *base* when required? Answer: HPA can be implemented as an incremental update.
 
 ## Alternatives
 

--- a/operator/ODH-ADR-Operator-0004-replica-image-support.md
+++ b/operator/ODH-ADR-Operator-0004-replica-image-support.md
@@ -8,7 +8,7 @@
 | Authors        | [Ajay Jaganathan](@AjayJagan), [Yauheni Kaliuta](@ykaliuta) |
 | Supersedes     | N/A |
 | Superseded by: | N/A |
-| Tickets        | [Tracker issue](https://github.com/opendatahub-io/opendatahub-operator/issues/441)|
+| Tickets        | [Tracker issue1](https://issues.redhat.com/browse/RHOAIENG-277)|
 | Other docs:    | none |
 
 ## What
@@ -28,9 +28,9 @@ NOTE: The image update is targeted for dev purposes and will not be available in
   components:
      workbenches:
         managementState: Managed
-        notebookController:
+        notebook-controller-deployment:
             replicas: 1
-        kfNotebookController:
+        odh-notebook-controller-manager:
             replicas: 1
   ```
 * For each component(eg. codeflare, ray, kserve etc) provide an image(s) field in the *devFlags* through which we can pass-in a custom image(s) to be used by the controller. Example yaml is given below:
@@ -39,9 +39,9 @@ NOTE: The image update is targeted for dev purposes and will not be available in
   components:
      workbenches:
         managementState: Managed
-        notebookController:
+        notebook-controller-deployment:
             replicas: 1
-        kfNotebookController:
+        odh-notebook-controller-manager:
             replicas: 1
         devFlags:
           images:
@@ -63,6 +63,7 @@ NOTE: The image update is targeted for dev purposes and will not be available in
             cpu: 200m
             memory: 256Mi
   ```  
+NOTE: The subcomponent names have to match exactly with the deployment names.
 
 ## Non-Goals
 
@@ -74,13 +75,13 @@ NOTE: The image update is targeted for dev purposes and will not be available in
   components:
     dashboard:
       managementState: Managed
-      dashboard:
+      odh-dashboard:
         autoscale:
           hpa:
             minReplicas: 1
             maxReplicas: 10
   ```   
-  
+  NOTE: HPA implementation is not a goal of this change.
 ## How
 
 The idea is to create a custom plugin for the kustomize where we use JSON patch to patch these updated values and then deploy the manifests.

--- a/operator/ODH-ADR-Operator-0004-replica-image-support.md
+++ b/operator/ODH-ADR-Operator-0004-replica-image-support.md
@@ -113,6 +113,7 @@ N/A
 
 ## Reviews
 
-| Reviewed by                   | Date       | Notes |
-| ----------------------------- | ---------  | ------|
-| name                          | date       | ? |
+| Reviewed by                   | Date          | Notes |
+| ----------------------------- | ---------     | ------|
+| Edson Tirelli                 | Jan 11, 2024  | ?     |
+| Andrew Ballantyne             | Jan 10, 2024  | ?     |

--- a/operator/ODH-ADR-Operator-0004-replica-image-support.md
+++ b/operator/ODH-ADR-Operator-0004-replica-image-support.md
@@ -1,0 +1,68 @@
+# Open Data Hub - Extend DataScienceCluster api to support per-Component tuning
+
+|                |            |
+| -------------- | ---------- |
+| Date           | 2023-Dec-1  |
+| Scope          | OpenDataHub operator |
+| Status         | Draft |
+| Authors        | [Ajay Jaganathan](@AjayJagan), [Yauheni Kaliuta](@ykaliuta) |
+| Supersedes     | N/A |
+| Superseded by: | N/A |
+| Tickets        | [Tracker issue](https://github.com/opendatahub-io/opendatahub-operator/issues/441)|
+| Other docs:    | none |
+
+## What
+
+This document explains about upgrading the DSC CRD to support customizing the replica count, images and modifying the resource limits/requests of individual components.
+## Why
+
+Current operator design doesnot support changing the replica count and the images are hard-coded in the manifests. A lot of teams and users have started requesting for providing support of manipulating these fields. 
+
+## Goals
+
+* For each component(eg. codeflare, ray, kserve etc) provide a field `replicas` through which we can modify the the Deployment's replica count.
+* For each component(eg. codeflare, ray, kserve etc) provide an image field through which we can pass-in a custom image to be used by the controller.
+* Certain components uses other images(for eg. datascience-pipelines-controller uses `IMAGE_API_SERVER`, `IMAGES_ARTIFACT`). We need to provide support to customize these images as well.
+* Control the resource limits and requests for individual components for more fine grained control.
+
+## Non-Goals
+
+* 
+## How
+
+The idea is to create a custom plugin for the kustomize where we use JSON patch to patch these updated values and then deploy the manifests.
+
+## Open Questions
+
+- What is the best way to implement this? Should we fetch the Deployment, read the env array, apply the changes then patch the changes.
+- The requirement suggests to update the images in env, in this case JSON patch doesnot support selecting maps in an array using the key value. It allows us to select only using the array index(here env being the array). Will the env always have the same ordering of its values? If we choose the array index method, it is pretty fragile. Either some sort of strategic merge or implementing own 'plugin'?
+
+## Alternatives
+
+N/A
+
+## Security and Privacy Considerations
+
+N/A
+
+## Risks
+
+- Providing an invalid image value can break the respective deployment.
+- Since we control the resource limits and requests, there is a possibility for over/under utilization for the resources.
+
+## Stakeholder Impacts
+
+| Group                         | Key Contacts     | Date       | Impacted? |
+| ----------------------------- | ---------------- | ---------- | --------- |
+| group or team name            | key contact name | date       | ? |
+
+
+## References
+
+* optional bulleted list
+
+## Reviews
+
+| Reviewed by                   | Date       | Notes |
+| ----------------------------- | ---------  | ------|
+| name                          | date       | ? |


### PR DESCRIPTION
Update DSC CRD with new customization values.

## Description
Upgrade the DSC CRD to support customizing the replica count, images and modifying the resource limits/requests of individual components.

