### PR TITLE
Fix RHOAI Operator diagram link

### DIFF
--- a/documentation/arch-overview.md
+++ b/documentation/arch-overview.md
@@ -113,7 +113,7 @@ Management
 
     -   Meta-operator for all RHOAI components and sub-operators. Responsible for deploying and maintaining all components.
   
-    ![Operator Architecture Overview](images/RHOAI%20Architecture%20-%20D3%20-%20Workbenches.png) 
+    ![Operator Architecture Overview](images/RHOAI%20Architecture%20-%20D1%20-%20Operator.png) 
 
 
 -   Prometheus


### PR DESCRIPTION


## Description
The overview document linked to the Workbenches diagram under the RHOAI Operator section. Changed to the correct diagram

## How Has This Been Tested?
Opened the [updated document](https://github.com/asmigala/architecture-decision-records/blob/fix-arch-overview-operator-diagram/documentation/arch-overview.md) in github ui and verified the correct image is present.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
