### PR TITLE
Create ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md

### DIFF
--- a/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
+++ b/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
@@ -1,0 +1,54 @@
+# Open Data Hub - Add test-only OpenTelemetry tracing instrumentation
+
+
+|                |                                                             |
+| -------------- |-------------------------------------------------------------|
+| Date           | 2025-04-02                                                  |
+| Scope          | Open Data Hub                                               |
+| Status         | Draft                                                       |
+| Authors        | [Jiri Danek](@jiridanek)                                    |
+| Supersedes     | N/A                                                         |
+| Superseded by: | N/A                                                         |
+| Tickets        |                                                             |
+| Other docs:    |                                                             |
+
+## What
+
+Add OpenTelemetry tracing instrumentation to newly written and modified odh-notebook-controller code.
+
+## Why
+
+OpenTelemetry traces are a powerful observability signal that can assist with testing the product. 
+
+Eventually, but not right now, we may even consider integrating with https://kubernetes.io/docs/concepts/cluster-administration/system-traces/ to trace across Kubernetes components.
+
+## Goals
+
+* Enable tracing only for testing (envtest testing) and not for production deployments.
+* Allow writing tests that check for events in order to assert for otherwise invisible properties of the software. Such as whether a specific error condition (that is transparently retried later) has been hit.
+
+## Non-Goals
+
+* Enabling OpenTracing in production deployments. This can be considered later, separately.
+
+## How
+
+* https://github.com/opendatahub-io/kubeflow/pull/570
+* When a TraceProvider is not configured, the OpenTelemetry library in Go defaults to noop trace provider
+* TraceProvider is to be only set when running tests, which ensures that there is no active tracing in production deployments.
+
+## Alternatives
+
+1. Writing a test that reads and parses debug log messages is feasible, but suboptimal when OpenTelemetry is also an option.
+
+## Stakeholder Impacts
+
+| Group                 | Key Contacts      | Date       | Impacted? |
+|-----------------------|-------------------| ---------- | --------- |
+| IDE Team              | @harshad16        | date       | / |
+
+## Reviews
+
+| Reviewed by   | Date       | Notes |
+|---------------|------------| ------|
+|  | 2025-04-02 | ? |

--- a/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
+++ b/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
@@ -1,16 +1,16 @@
 # Open Data Hub - Add test-only OpenTelemetry tracing instrumentation
 
 
-|                |                                                             |
-| -------------- |-------------------------------------------------------------|
+| Field          | Value                                                       |
+| -------------- | ----------------------------------------------------------- |
 | Date           | 2025-04-02                                                  |
 | Scope          | Open Data Hub                                               |
 | Status         | Draft                                                       |
 | Authors        | [Jiri Danek](@jiridanek)                                    |
 | Supersedes     | N/A                                                         |
-| Superseded by: | N/A                                                         |
-| Tickets        |                                                             |
-| Other docs:    |                                                             |
+| Superseded by  | N/A                                                         |
+| Tickets        | N/A                                                         |
+| Other docs     | N/A                                                         |
 
 ## What
 

--- a/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
+++ b/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
@@ -45,7 +45,7 @@ Eventually, but not right now, we may even consider integrating with https://kub
 
 | Group                 | Key Contacts      | Date       | Impacted? |
 |-----------------------|-------------------| ---------- | --------- |
-| IDE Team              | @harshad16        | date       | / |
+| IDE Team              | @harshad16        | 2025-05-14       | yes|
 
 ## Reviews
 

--- a/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
+++ b/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
@@ -44,7 +44,7 @@ Eventually, but not right now, we may even consider integrating with https://kub
 ## Stakeholder Impacts
 
 | Group                 | Key Contacts      | Date       | Impacted? |
-|-----------------------|-------------------| ---------- | --------- |
+|-----------------------|-------------------|------------|-----------|
 | IDE Team              | @harshad16        | 2025-05-14       | yes|
 
 ## Reviews

--- a/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
+++ b/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
@@ -51,4 +51,4 @@ Eventually, but not right now, we may even consider integrating with https://kub
 
 | Reviewed by   | Date       | Notes |
 |---------------|------------| ------|
-|  | 2025-04-02 | ? |
+| @harshad16  | 2025-05-14 | no additional notes |

--- a/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
+++ b/architecture-decision-records/workbenches/ODH-ADR-0001-add-test-only-opentelemetry-instrumentation.md
@@ -34,8 +34,8 @@ Eventually, but not right now, we may even consider integrating with https://kub
 ## How
 
 * https://github.com/opendatahub-io/kubeflow/pull/570
-* When a TraceProvider is not configured, the OpenTelemetry library in Go defaults to noop trace provider
-* TraceProvider is to be only set when running tests, which ensures that there is no active tracing in production deployments.
+* When a TracerProvider is not configured, the OpenTelemetry-Go library defaults to a no-op provider.
+* A TracerProvider is configured only during tests, ensuring no active tracing in production deployments.
 
 ## Alternatives
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* https://github.com/opendatahub-io/kubeflow/pull/570

replacement for

* https://github.com/opendatahub-io/notebooks/pull/858

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new architecture decision record detailing the introduction of test-only OpenTelemetry tracing instrumentation to improve observability during testing without impacting production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->