### PR TITLE
Update the OdhDashbaordConfig admins to Auth admins

### DIFF
--- a/documentation/components/dashboard/README.md
+++ b/documentation/components/dashboard/README.md
@@ -239,7 +239,19 @@ There are fundamentally 3 types of users to understand.
 
 Admins today are determined by being in one of these groups:
 
-* The OdhDashboardConfig resource has a field for "admin_groups"; any valid OpenShift Group resource listed here is considered an admin group -- any users within should see the Settings navigation
+* Using the platform's `Auth` resource -- `adminGroups` specifies the groups of admins
+    ```yaml
+    apiVersion: services.platform.opendatahub.io/v1alpha1
+    kind: Auth
+    metadata:
+      name: auth
+    spec:
+      adminGroups:
+        - rhods-admins
+      allowedGroups:
+        - 'system:authenticated'
+    ```
+    * These groups get role bindings applied to them and granted access
 * The `cluster-admin` Role is granted in a RoleBinding to the user
 
 Note: Any other ways today, including comprehensive Role bindings or the initial kube:admin user do not inherently get the definition of an admin.


### PR DESCRIPTION
Updating Dashboard Readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dashboard admin configuration guidance to use the platform’s Auth resource for managing admin groups.
  * Added examples showing how to declare admin and allowed groups, and clarified how access is granted via role bindings.
  * Clarified that alternative methods do not automatically grant admin privileges.
  * Noted that existing cluster-admin mapping behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->