### PR TITLE
two ADRs for MCP management

### DIFF
--- a/architecture-decision-records/mcp/ODH-ADR-MCP-0001-toolhive-mcp-management.md
+++ b/architecture-decision-records/mcp/ODH-ADR-MCP-0001-toolhive-mcp-management.md
@@ -1,0 +1,130 @@
+|                |            |
+| -------------- | ---------- |
+| Date           | 25-NOV-2025 |
+| Scope          | |
+| Status         | Approved |
+| Authors        | Gordon Sim (@grs) |
+| Supersedes     | N/A |
+| Superseded by: | N/A |
+| Tickets        | |
+| Other docs:    | none |
+
+## What
+
+This ADR concerns the selection of a solution for managing the
+deployment of MCP (Model Context Protocol) servers and the configuring
+of intermediaries through which they will be accessed in order to
+control and observe interactions.
+
+## Why
+
+Users are looking for ways to mitigate the inherent risks associated
+with use of MCP. Providing a solution that helps them manage the
+deployment of MCP servers and ensures that all traffic to and from
+them goes through an intermediary - a proxy or gateway through which
+use can be controlled and observed - helps with that.
+
+## Goals
+
+* A declarative solution for deployment of MCP servers and
+  configuration of intermediated traffic to and from them.
+
+## Non-Goals
+
+* The solution selected here is not intended to impact the plans for
+  MCP servers that are part of the OpenShift platform. Those will
+  continue to use kagenti/mcp-gateway.
+ 
+## How
+
+ToolHive provides an MCP proxy that supports access control (including
+token verification, token exchange, fine-grained access control over
+tools), observability and the ability to limit (and even rename or
+redescribe) tools, along with a CRD-based API for simple deployment
+and configuration of MCP servers that are then automatically
+configured to be accessed through an instance of this proxy.
+
+This will form the basis of a solution to manage the use of MCP for
+OpenShift users.
+
+ToolHive also has support for registries serving the API as defined by
+Anthropic's MCP registry. This ADR does not propose to use that
+aspect.
+
+## Open Questions
+
+N/A
+
+## Alternatives
+
+### kagenti/mcp-gateway
+
+The kagenti/mcp-gateway project was created to secure access to MCP servers
+for controlling the OpenShift platform itself. Using that as an
+intermediary for users' own MCP servers, and augmenting the solution
+with a CRD-based API for automatic deployment of those servers and
+configuration for access through the gateway, similar to the full
+solution ToolHive provides, was considered.
+
+However at present there is only one gateway per cluster and all tools
+exposed through it are prefixed. That limitation is scheduled to be
+addressed in mcp-gateway, but in the short term is not sufficiently
+flexible. Installation of mcp-gateway also requires Istio and for
+access control would require Kuadrant, whereas ToolHive is
+self-contained which reduces short term risk.
+
+### kagent-dev/kmcp
+
+The kagent-dev/kmcp project is similar to ToolHive, offering a CRD
+based API to deploy MCP servers and configure them to be accessed
+through the agentgateway. At present however ToolHive seems to have
+more features and more visibility.
+
+## Security and Privacy Considerations
+
+The robustness and correctness of the ToolHive MCP proxy can affect
+security. The proxy image would be particularly sensitive to CVEs as
+it would be relied upon for access control and all MCP traffic would
+go through it.
+
+## Risks
+
+The MCP ecosystem is evolving rapidly. The kagenti/mcp-gateway project
+will evolve. There will also be other work done to enable MCP support
+in envoy as well as work ongoing in the Kubernetes community to
+consider changes to the Gateway API necessary for AI-related use, such
+as for proxying MCP requests. There is a risk that changes in the
+ecosystem require this decision to be re-evaluated in the future.
+
+The ToolHive project is also fast-moving and the vast majority of
+contributions so far come from the founding company. Though Daniele
+Martinoli and Roddie Kieley from Red Hat's Ecosystem Engineering have
+been contributing to the project for some time now, there is a risk
+that we struggle to get in any changes that we make and/or that the
+project moves in directions that make it less suitable for our needs.
+
+There is also uncertainty around the time and effort required to productize
+the ToolHive components and integrate them into OpenShift AI, which could
+impact delivery timelines.
+
+There is also a risk that MCP as a protocol fades in relevance over
+time.
+
+## Stakeholder Impacts
+
+| Group                         | Key Contacts     | Date       | Impacted? |
+| ----------------------------- | ---------------- | ---------- | --------- |
+|                               |                  |            | ?         |
+
+
+## References
+
+* [ToolHive](https://github.com/stacklok/toolhive)
+* [mcp-gateway](https://github.com/kagenti/mcp-gateway)
+* [kmcp](https://github.com/kagent-dev/kmcp)
+
+## Reviews
+
+| Reviewed by                   | Date       | Notes |
+| ----------------------------- | ---------  | ------|
+| name                          | date       | ? |

--- a/architecture-decision-records/mcp/ODH-ADR-MCP-0002-mcp-management-api.md
+++ b/architecture-decision-records/mcp/ODH-ADR-MCP-0002-mcp-management-api.md
@@ -1,0 +1,121 @@
+|                |            |
+| -------------- | ---------- |
+| Date           | 05-DEC-2025 |
+| Scope          | |
+| Status         | Approved |
+| Authors        | Gordon Sim (@grs) |
+| Supersedes     | N/A |
+| Superseded by: | N/A |
+| Tickets        | |
+| Other docs:    | none |
+
+## What
+
+This ADR concerns a decision on the appropriate API for managing the
+configuration of MCP (Model Context Protocol) servers and the
+intermediaries through which they will be accessed to control and
+observe interactions.
+
+## Why
+
+Platform owners want to allow users of the platform to select the MCP
+servers they wish to run, while ensuring that they are configured
+appropriately. This would be best achieved by an API that reflects
+these two distinct roles, allowing platform owners (or those to whom
+they delegate the task) to pre-define the configuration they wish to
+control, while letting users of the platform select which of the
+approved MCP servers they wish to deploy.
+
+## Goals
+
+* A declarative API for managing the deployment and configuration of
+  MCP servers and the intermediaries through which they are accessed.
+
+## Non-Goals
+
+* Selection of the intermediary to use or details of the
+  implementation, which is covered by a separate ADR
+  [ODH-ADR-MCP-0001].
+ 
+## How
+
+Two new CRDs will be introduced. One will be namespace-scoped and
+named MCPServerRequest (or similar). This will be used by platform
+users to indicate that they want to run a particular approved MCP
+server in that namespace. The other will be cluster-scoped and named
+MCPServerPolicy (or similar). It will be used by platform owners to
+define an allowed MCP server and the configuration of that server and
+the intermediary through which it will be accessed.
+
+A controller will process a given MCPServerRequest for which there is
+a matching MCPServerPolicy defined that applies to the relevant
+namespace, and create CRs necessary to realise the desired MCP
+server. E.g. in the case of using ToolHive, an MCPServer CR from the
+ToolHive API would be created.
+
+It should be noted that this mechanism does not by itself prevent
+undesired use of MCP. Any user with the ability create pods can run
+any image and configuration the platform allows. Either that ability
+must be restricted to those that are trusted or some other means of
+restricting images used on the cluster for any purpose needs to be in
+place. The mechanism proposed here is intended to allow the policy to
+be defined and make it easy to follow that, but is not intended to
+thwart malicious use.
+
+## Open Questions
+
+N/A
+
+## Alternatives
+
+An alternative would be to use the ToolHive API directly. However, as
+that API does not separate the configuration that should be centrally
+defined from anything that can be left to the requesting user to
+decide. This approach doesn't therefore really allow for a
+self-service model with predefined configuration.
+
+## Security and Privacy Considerations
+
+N/A
+
+## Risks
+
+There is a risk that platform operators with established container
+governance and RBAC mechanisms may prefer to continue using those
+familiar tools rather than adopting the abstractions proposed here,
+limiting the perceived value and adoption of this capability. Offering
+a concrete, if tentative, solution is a way to open up those
+conversations however.
+
+There is also a relatively high risk that the proposed API would not
+see wide adoption outside OpenShift AI. However, at this time there
+isn't any real alternative that supports the self-service model. As
+the ecosystem evolves, something new may emerge or some existing
+solution may gain significant traction and alter the way requirements
+are viewed. At such time this decision would need to be re-evaluated,
+including perhaps defining some migration path.
+
+However the burden of maintaining this layer is relatively small. It
+does also allow different realisations of the requested MCP servers,
+which could for example allow some MCP servers to be secured using
+ToolHive and others using kagenti/mcp-gateway, either to support both
+or to support migration from one to the other.
+
+There is also a risk that MCP as a protocol fades in relevance over
+time.
+
+## Stakeholder Impacts
+
+| Group                         | Key Contacts     | Date       | Impacted? |
+| ----------------------------- | ---------------- | ---------- | --------- |
+|                               |                  |            | ?         |
+
+
+## References
+
+
+## Reviews
+
+| Reviewed by                   | Date       | Notes |
+| ----------------------------- | ---------  | ------|
+| name                          | date       | ? |


### PR DESCRIPTION
An ADR for selection of ToolHive for MCP Management and another for an API layer in front of it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an ADR describing the approach for managing MCP server deployment and using intermediaries (proxies/gateways) to control and observe MCP traffic; includes scope, alternatives, risks, security/privacy considerations, and open questions.
  * Added an ADR defining a declarative API and management framework for MCP server lifecycle and configuration, using namespace-scoped requests reconciled against cluster/namespace policies to produce managed deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->