### PR TITLE
Update dashboard documentation to reflect current codebase state

### DIFF
--- a/documentation/components/dashboard/README.md
+++ b/documentation/components/dashboard/README.md
@@ -206,8 +206,7 @@ There are a few exceptions that are mostly deprecated and have a desire to be re
         * **Future Goal:** Likely required to stay on the Service Account, but infrastructure may be able to change so its less Admin vs User and "what you have access to"
     * The Dashboard Service Account manages getting the needed information to validate and operate on these functionalities
 * [Admin access](#admins) (aka "Settings" navigation)
-    * All UI admin functionality is done by the Service Account despite the user maybe having valid permissions to do so
-    * **Future Goal:** Empower those picked as Admins to have direct permissions & shift to a SSAR model for Admin views
+    * Admin functionality now uses SelfSubjectAccessReview (SSAR) checks to determine user permissions. The backend uses SSAR for `isUserAdmin` and `isUserAllowed` checks, and the frontend uses `useAccessReview` hooks. Some admin operations still fall back to the Service Account where direct user RBAC is not yet fully available.
 
 ### Fundamental User Types
 
@@ -269,7 +268,10 @@ Current supported OpenShift AI components are:
 - Model Serving
 - Platform
 - Distributed Workloads
-- Model Registry (soon)
+- Model Registry
+- Model Catalog
+- Connections
+- Fine-Tuning / InstructLab
 
 Concepts not provided by OpenShift AI that are supported are:
 
@@ -285,8 +287,8 @@ More details:
 
 * Initially there was an intent to have Projects created by the Dashboard to have specific flows to provide to users; this since has become a point of confusion and frustration trying to extend existing Projects
 * Projects created in the Dashboard have a `opendatahub.io/dashboard` label to indicate they are Dashboard Data Science Projects
-* Some namespaces are ignored despite permissions, these are namespaces that are not intended for data science flows (infrastructure namespaces, configuration namespaces, etc)
-* Most resources within projects have the `opendatahub.io/dashboard` label to help indicate their intent for Data Science flows
+* Some namespaces are ignored despite permissions, these are namespaces that are not intended for data science flows. Specifically, namespaces matching `openshift-*`, `kube-*`, `default`, `system`, `openshift`, and the Dashboard's own deployment namespace are filtered out using name-pattern filtering (not label-based filtering).
+* Most resources within projects have the `opendatahub.io/dashboard` label to help indicate their intent for Data Science flows. The label is still used for resource identification (e.g., model serving projects) but is no longer required for project listing.
     * Note: There is a goal to reduce this to pure K8s resources and all AI custom resources (Notebook, ServingRuntimes, InferenceServices, etc) should not need the label 
 
 > Note: You can read more about `opendatahub.io/dashboard` in [Dashboard K8s Labels & Annotations](./k8sLabelsAndAnnotations.md#opendatahubiodashboard)
@@ -325,20 +327,20 @@ These resources provide access to link to external documentation about how-tos a
 
 These resources provide access to have embedded quick starts, where the users can access the quick start and follow a guided experience.
 
-### AcceleratorProfiles
+### AcceleratorProfiles (deprecated)
 
 **acceleratorprofiles.dashboard.opendatahub.io/v1**
 
-> **Note:** This resource is fully configurable with in-app Admin flows
+> **Note:** AcceleratorProfiles are deprecated and have been replaced by [HardwareProfiles](#hardwareprofiles). The `disableAcceleratorProfiles` feature flag is deprecated and immutable. AcceleratorProfiles remain only for backward compatibility and will be removed in a future version.
 
-These resources help provide information of your accelerators on your cluster and gives the admin the ability to configure or disable them as they see fit. In turn, the user can get access to "profiles" of how
+These resources help provide information of your accelerators on your cluster and gives the admin the ability to configure or disable them as they see fit. In turn, the user can get access to profiles describing the accelerator resources (e.g., GPU type and count) available for selection when launching workloads such as Workbenches and Model Serving.
 
 ### HardwareProfiles
 
-**hardwareprofiles.dashboard.opendatahub.io/v1alpha1**
+**hardwareprofiles.infrastructure.opendatahub.io/v1**
 
-> **Note:** This resource is fully configurable with in-app Admin flows
+> **Note:** This resource is fully configurable with in-app Admin flows. HardwareProfiles are GA and cannot be disabled.
 
-The HardwareProfiles CRD provides a declarative way for administrators to define compute profiles that control the CPU, memory, and other resource constraints available for workloads in OpenShift AI. These profiles are surfaced to end users to select when launching workloads such as Workbenches.
+The HardwareProfiles CRD provides a declarative way for administrators to define compute profiles that control the CPU, memory, and other resource constraints available for workloads in OpenShift AI. These profiles are surfaced to end users to select when launching workloads such as Workbenches. HardwareProfiles replace both the deprecated AcceleratorProfiles CRD and the deprecated `notebookSizes`/`modelServerSizes` fields on OdhDashboardConfig.
 
 Admins can configure profiles directly within the Dashboard, enabling or disabling profiles, as well as setting minimums, maximums, and default values for CPU, memory, and other resources (e.g., GPUs).

--- a/documentation/components/dashboard/configuringDashboard.md
+++ b/documentation/components/dashboard/configuringDashboard.md
@@ -72,7 +72,7 @@ Our configuration would look something like this:
 const configurations = {
   [SupportedArea.DS_PIPELINES]: {
     featureFlags: ['disablePipelines'],
-    requiredComponents: [StackComponent.DS_PIPELINES],
+    requiredComponents: [DataScienceStackComponent.DS_PIPELINES],
   },
   // ...
 }
@@ -93,14 +93,17 @@ See the comprehensive list below for Dashboard-specific aspects.
 
 > Note: For this list, each item will be flagged with **(UI)** or **(API)**. UI features have a UI flow and can be configured through API as needed (aka outside of the UI). API features are not able to be configured inside the UI and can only be configured outside of the UI.
 
-* Workbench Container Sizes **(API)**
+* Workbench Container Sizes **(API)** -- **DEPRECATED: Use HardwareProfiles instead.**
   > Visible during creation of a Workbench & Jupyter tile's Notebooks
     * Configured through the [OdhDashboardConfig] `.spec.notebookSizes` an array of resource objects (memory & cpu limits/requests)
     * We have a fallback default if not provided
-* Model Serving Container Sizes **(API)**
+    * This field is deprecated and will be removed in a future version. HardwareProfiles (`hardwareprofiles.infrastructure.opendatahub.io/v1`) are the replacement mechanism.
+* Model Serving Container Sizes **(API)** -- **DEPRECATED: Use HardwareProfiles instead.**
   > Visible during the creation of a Model Server (or KServe model)
-    * Configured through the [OdhDashboardConfig] `.spec.modelServingSizes` an array of resource objects (memory & cpu limits/requests)
+    * Configured through the [OdhDashboardConfig] `.spec.modelServerSizes` an array of resource objects (memory & cpu limits/requests)
     * We have a fallback default if not provided
+    * This field is deprecated and will be removed in a future version. HardwareProfiles are the replacement mechanism.
 * Jupyter Tile configurations **(UI)**
     * PVC Size through the [OdhDashboardConfig] `spec.notebookController.pvcSize`
-* Telemetry
+* Telemetry **(API)**
+    * Controlled by the `disableTracking` feature flag in the [OdhDashboardConfig]

--- a/documentation/components/dashboard/dashboardStorage.md
+++ b/documentation/components/dashboard/dashboardStorage.md
@@ -1,5 +1,6 @@
 [Workbench component documentation]: ../workbenches
-[AcceleratorProfiles]: ./README.md#acceleratorprofiles
+[AcceleratorProfiles]: ./README.md#acceleratorprofiles-deprecated
+[HardwareProfiles]: ./README.md#hardwareprofiles
 
 # Dashboard Storage Mechanisms
 
@@ -37,12 +38,15 @@ Features that impact all users or the Dashboard itself. These are only available
 * Cluster Settings' Notebook Culler
     * This is configured by the Notebook Controller feature
     * Stored today as `notebook-controller-culler-config` ConfigMap in the deployment namespace (see [Workbench component documentation] for more information)
-* Accelerator profiles
-    * These are stored as [AcceleratorProfiles]
+* Accelerator profiles (deprecated)
+    * These are stored as [AcceleratorProfiles] -- deprecated, replaced by HardwareProfiles
+* Hardware profiles
+    * These are stored as [HardwareProfiles] CRDs (`hardwareprofiles.infrastructure.opendatahub.io/v1`). HardwareProfiles replace both AcceleratorProfiles and the deprecated `notebookSizes`/`modelServerSizes` fields on OdhDashboardConfig.
 * Notebook images
     * These are stored as ImageStreams in the deployment namespace
 * Serving Runtimes
-    * These are stored as OpenShift Templates in the deployment namespace
+    * Admin-managed (global) serving runtimes are stored as OpenShift Templates wrapping ServingRuntime CRs in the deployment namespace
+    * Project-scoped serving runtimes are stored as direct ServingRuntime CRs in the user's project namespace
       > Note: OpenShift Templates was an idea of future feature expansion and are not executed as OpenShift Templates today.
 * Connection Types
     * These are stored as ConfigMaps in the deployment namespace
@@ -61,13 +65,13 @@ Connections is a concept created by the Dashboard to store information and enabl
 kind: Secret
 apiVersion: v1
 metadata:
-  name: aws-connection-<user-inputted-value>
+  name: <user-inputted-value>
   namespace: <users-namespace>
   labels:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/managed: 'true'
   annotations:
-    opendatahub.io/connection-type: s3
+    opendatahub.io/connection-type-ref: s3
     openshift.io/display-name: <users-driven-display-name>
 data:
   AWS_ACCESS_KEY_ID: <value>
@@ -77,6 +81,10 @@ data:
   AWS_SECRET_ACCESS_KEY: <value>
 type: Opaque
 ```
+
+> Note: The `opendatahub.io/connection-type-ref` annotation (introduced in 2.16) is the primary annotation for identifying the connection type schema. The legacy `opendatahub.io/connection-type` annotation is still recognized as a fallback. Additionally, connections may include the `opendatahub.io/connection-type-protocol` annotation (3.0+) for protocol-based validation and routing.
+
+> Note: The `aws-connection-` name prefix shown in older examples is a legacy naming convention from the original S3-only Data Connections. New connections created through the Connection Type system do not use this prefix.
 
 See more information on the labels & annotations in the [Connection section of the K8s Labels & Annotations](./k8sLabelsAndAnnotations.md#connections)
 

--- a/documentation/components/dashboard/features/README.md
+++ b/documentation/components/dashboard/features/README.md
@@ -6,9 +6,9 @@ It is worth noting, some of this information will talk about other backend featu
 
 ## Features
 
-1. [Data Connections - Connection Types - Connections](./connections.md)
-
-Additional specific feature details coming soon...
+1. [Connections (formerly Data Connections) - Connection Types](./connections.md)
+2. [Model Catalog](./modelCatalog.md)
+3. [Model Registry](./modelRegistry.md)
 
 <!-- TODO: Model Serving Tokens -->
 <!-- TODO: Jupyter Tile & Notebook Namespace (ex. rhods-notebooks) -->

--- a/documentation/components/dashboard/features/connections.md
+++ b/documentation/components/dashboard/features/connections.md
@@ -16,7 +16,7 @@
 
 There are three terms we are working with here:
 
-* **Data Connections** -- The "old" (no longer used) term. This indicated the S3-compatible Data Connection that we had prior to 2.16; moving forward these are _Connections_ based on the S3 _Connection Type_ (which comes [ootb](#out-of-the-box-ootb-offerings))
+* **Data Connections** -- The former term, fully replaced by _Connections_ in the UI as of 2.16. The old S3-compatible Data Connections are now _Connections_ based on the S3 _Connection Type_ (which comes [ootb](#out-of-the-box-ootb-offerings)). The term "Data Connections" no longer appears in the UI.
 * **Connection Types** -- These are like templates for new _Connections_. These are crafted & managed by the RHOAI admins and stored inside the deployment namespace; some come [ootb](#out-of-the-box-ootb-offerings)
 * **Connections** -- These are the instances inside a Data Science Project that can be connected to Workbenches & Model Serving Models, they are always based off a _Connection Type_
 
@@ -112,15 +112,18 @@ Connections don't do a lot by themselves; they effectively store configurations 
 
 ### Workbench Connections
 
-Workbenches are by far the most flexible of Connection consumers. All Connections are connected via `envFrom` (see below for an example), which injects all the keys of the Secret as environment variables. Consumption of the data can be done through the Workbenches' standard access to the environment variables (in Python that's `os.environ["ENV_NAME_HERE"]`).
+Workbenches are by far the most flexible of Connection consumers. All Connections are injected as environment variables, and consumption of the data can be done through the Workbenches' standard access to the environment variables (in Python that's `os.environ["ENV_NAME_HERE"]`).
 
-Under the hood -- the connectivity between a Connection and a Workbench exists as such:
+The primary mechanism for connecting a Workbench to Connections is the `opendatahub.io/connections` annotation on the Notebook resource. This annotation contains a comma-separated list of `<namespace>/<secret-name>` references:
 
 ```yaml
 apiVersion: kubeflow.org/v1
 kind: Notebook
 metadata:
   name: example-workbench
+  namespace: my-project
+  annotations:
+    opendatahub.io/connections: 'my-project/my-s3-connection,my-project/my-uri-connection'
   # ...other properties
 spec:
   template:
@@ -129,14 +132,18 @@ spec:
       containers:
         - name: the-notebook-container
           # ...other properties
-          envFrom:
-            - secretRef:
-                name: my-s3-connection
-            - secretRef:
-                name: my-uri-connection
 ```
 
-The `my-s3-connection` (using the ootb S3 Connection Type) & `my-uri-connection` (using the ootb URI Connection Type) are connected via the `envFrom` section on the notebook container. Since all Connections are secrets & are injected the same way as environment variables, it will always be mounted from `envFrom.secretRef.name` for each Connection irrespective of their structure.
+The namespace prefix in the annotation value allows the system to perform a SubjectAccessReview to verify that the user has permission to access the Secret. The operator controller then handles injecting the connection secrets as environment variables into the Notebook container.
+
+> Note: The legacy approach of directly specifying connections via `envFrom.secretRef` in the Notebook spec is still supported for backward compatibility:
+> ```yaml
+> containers:
+>   - name: the-notebook-container
+>     envFrom:
+>       - secretRef:
+>           name: my-s3-connection
+> ```
 
 > Note: It is important to note that since they are injected as environment variables, two Connections sharing the same variable will clobber each other and the "last one" wins. The UI will note this concern when you have two Connections overlapping.
 
@@ -150,6 +157,12 @@ Essentially we only have support for these types:
 * [OCI model cars](#oci-model-cars-connection)
 
 > Note: At this time there is not much else that can be done as it requires specific integration logic in order to connect a specific set of fields from the Connection to align it with the implementation of the Serving feature (KServe, Model Mesh, etc).
+
+> Note: In addition to the resource-level integration shown below, InferenceServices can also use the `opendatahub.io/connections` annotation (a single connection reference, no namespace prefix needed) to associate a connection with the serving resource. This annotation is consumed by the operator for validation and routing.
+
+**Supported workloads consuming connections:**
+* `InferenceService` (KServe Model Serving)
+* `LLMInferenceService` (LLM-D Model Serving)
 
 #### S3-compatible Connection
 

--- a/documentation/components/dashboard/features/modelCatalog.md
+++ b/documentation/components/dashboard/features/modelCatalog.md
@@ -35,7 +35,7 @@ The initial version of Model Catalog introduced in 2.19 and enhanced in 2.20 was
 
 A BFF-based Model Catalog API (`/api/model_catalog/v1alpha1`) now exists alongside the ConfigMap approach. The frontend continues to use the ConfigMaps (`model-catalog-sources` and `model-catalog-unmanaged-sources`) while the BFF layer provides a structured API for upstream integration. The long-term goal is for the API to fully replace the ConfigMap approach, allowing the dashboard to fetch and search/filter remote repositories of model metadata.
 
-For more details on the ConfigMap implementation and how the model metadata is updated, see [this README in the model registry repo](https://github.com/opendatahub-io/model-registry/tree/main/model-catalog).
+For more details on the ConfigMap implementation and how the model metadata is updated, see [this README in the model registry repo](https://github.com/kubeflow/model-registry/tree/main/catalog).
 
 ## Terms
 

--- a/documentation/components/dashboard/features/modelCatalog.md
+++ b/documentation/components/dashboard/features/modelCatalog.md
@@ -4,7 +4,7 @@
 
 - [Introduction](#introduction)
   - [Differences between Model Catalog and Model Registry](#differences-between-model-catalog-and-model-registry)
-  - [The Current Implementation Is Temporary](#the-current-implementation-is-temporary)
+  - [Implementation History](#implementation-history)
 - [Terms](#terms)
 - [Example Data](#example-data)
   - [`model-catalog-sources` ConfigMap (truncated)](#model-catalog-sources-configmap-truncated)

--- a/documentation/components/dashboard/features/modelCatalog.md
+++ b/documentation/components/dashboard/features/modelCatalog.md
@@ -1,6 +1,6 @@
 # Model Catalog
 
-> Introduced in 2.19 as Tech Preview
+> Introduced in 2.19 as Tech Preview, now GA
 
 - [Introduction](#introduction)
   - [Differences between Model Catalog and Model Registry](#differences-between-model-catalog-and-model-registry)
@@ -29,11 +29,13 @@ The Model Catalog feature provides a centralized list of AI models available for
 
 These are the differences as currently implemented. Some of this may change with future enhancements; for example, there is a desire to allow an admin to configure which models/sources a user has access to instead of the unrestricted access of the current implementation.
 
-### The Current Implementation Is Temporary
+### Implementation History
 
-The initial version of Model Catalog introduced in 2.19 and enhanced in 2.20 is built without a real backend API. Model metadata is stored in a ConfigMap on the cluster, which is [created automatically by the dashboard's manifests](https://github.com/opendatahub-io/odh-dashboard/tree/main/manifests/rhoai/shared/apps/model-catalog). No external sources are being accessed, we are hand-curating a set of models to be included with each release. This implementation is not sustainable and was only chosen to facilitate early demonstrations and user research. In the near future this ConfigMap approach will be replaced by the consumption of a new Model Catalog API provided alongside the Model Registry API. This will allow the dashboard to fetch and search/filter remote repositories of model metadata and present those models in the catalog.
+The initial version of Model Catalog introduced in 2.19 and enhanced in 2.20 was built without a real backend API. Model metadata was stored in ConfigMaps on the cluster, created automatically by the dashboard's manifests. No external sources were accessed; models were hand-curated and included with each release.
 
-For more details on the temporary ConfigMap implementation and how the model metadata is updated, see [this README in the model registry repo](https://github.com/opendatahub-io/model-registry/tree/main/model-catalog).
+A BFF-based Model Catalog API (`/api/model_catalog/v1alpha1`) now exists alongside the ConfigMap approach. The frontend continues to use the ConfigMaps (`model-catalog-sources` and `model-catalog-unmanaged-sources`) while the BFF layer provides a structured API for upstream integration. The long-term goal is for the API to fully replace the ConfigMap approach, allowing the dashboard to fetch and search/filter remote repositories of model metadata.
+
+For more details on the ConfigMap implementation and how the model metadata is updated, see [this README in the model registry repo](https://github.com/opendatahub-io/model-registry/tree/main/model-catalog).
 
 ## Terms
 

--- a/documentation/components/dashboard/features/modelRegistry.md
+++ b/documentation/components/dashboard/features/modelRegistry.md
@@ -1,6 +1,6 @@
 # Model Registry
 
-> Introduced in 2.16 as Tech Preview and GA'ed in 2.25. Fully implemented with feature flag (`disableModelRegistry`) under tech preview feature flags.
+> Introduced in 2.16 as Tech Preview, GA'ed in 2.25. Controlled by the `disableModelRegistry` feature flag (configured in the tech preview flags section of the dashboard).
 
 - [Introduction](#introduction)
   - [A Model Registry is a Metadata Service Only](#a-model-registry-is-a-metadata-service-only)
@@ -187,7 +187,7 @@ Inconsistency note: while a ModelVersion references its parent with a `registere
 
 - **Model Registry Permissions** -- The Model Registry settings page also allows the administrator to configure permissions for access to a model registry. This "manage permissions" view uses the same functionality as managing permissions for a Project: the admin can add users or groups, which creates RoleBindings to give those entities a role granting them access to see that registry and use its REST API. The role
   - **Project permissions** -- A project can also be added to a registry in the manage permissions view. This gives all service accounts in the project permission to see and use the registry.
-- **Listing Model Registries via Services** -- The non-admin user does not have permission to view ModelRegistry CRs, but the dashboard needs to be able to list them in order to populate the registry selector. Each registry has an associated Service resource, and a user with access to a registry can view that Service. To list the registries a user can see, the dashboard makes a SelfServiceRulesRequest to get the names of Services in the registries namespace and then fetches each of those Services. The model registry operator automatically syncs some metadata from the ModelRegistry CR to the Service (such as the display name and description) so non-admins have access to those details.
+- **Listing Model Registries via Services** -- The non-admin user does not have permission to view ModelRegistry CRs, but the dashboard needs to be able to list them in order to populate the registry selector. Each registry has an associated Service resource, and a user with access to a registry can view that Service. To list the registries a user can see, the dashboard makes a SelfSubjectRulesReview to get the names of Services in the registries namespace and then fetches each of those Services. The model registry operator automatically syncs some metadata from the ModelRegistry CR to the Service (such as the display name and description) so non-admins have access to those details.
 - **Usage of Service Account** -- Non-cluster-admin users (including ODH admins) do not have permission to create or view resources in the registries namespace (except Services). Admin operations on the Model Registry Settings page use the dashboard's service account. A BFF (Backend-for-Frontend) layer has been implemented (`packages/model-registry/upstream/bff/` in Go) which provides RBAC via `SelfSubjectRulesReview` and is part of the modular architecture.
   - The writing and reading of Secrets and ConfigMaps associated with the ModelRegistry CR (as described above in [Terms](#terms)) are handled by the backend and performed by the service account. Requests to the backend pass along the database password or certificate information and the underlying resources are abstracted away.
 

--- a/documentation/components/dashboard/features/modelRegistry.md
+++ b/documentation/components/dashboard/features/modelRegistry.md
@@ -1,6 +1,6 @@
 # Model Registry
 
-> Introduced in 2.16 as Tech Preview
+> Introduced in 2.16 as Tech Preview. Fully implemented with feature flag (`disableModelRegistry`) under tech preview flags.
 
 - [Introduction](#introduction)
   - [A Model Registry is a Metadata Service Only](#a-model-registry-is-a-metadata-service-only)
@@ -188,8 +188,8 @@ Inconsistency note: while a ModelVersion references its parent with a `registere
 - **Model Registry Permissions** -- The Model Registry settings page also allows the administrator to configure permissions for access to a model registry. This "manage permissions" view uses the same functionality as managing permissions for a Project: the admin can add users or groups, which creates RoleBindings to give those entities a role granting them access to see that registry and use its REST API. The role
   - **Project permissions** -- A project can also be added to a registry in the manage permissions view. This gives all service accounts in the project permission to see and use the registry.
 - **Listing Model Registries via Services** -- The non-admin user does not have permission to view ModelRegistry CRs, but the dashboard needs to be able to list them in order to populate the registry selector. Each registry has an associated Service resource, and a user with access to a registry can view that Service. To list the registries a user can see, the dashboard makes a SelfServiceRulesRequest to get the names of Services in the registries namespace and then fetches each of those Services. The model registry operator automatically syncs some metadata from the ModelRegistry CR to the Service (such as the display name and description) so non-admins have access to those details.
-- **Usage of Service Account** -- Non-cluster-admin users (including ODH admins) do not have permission to create or view resources in the registries namespace (except Services). Currently, admin operations on the Model Registry Settings page use the dashboard's service account via backend routes. This will change soon with the introduction of the BFF and modular architecture.
-  - Currently, the writing and reading of Secrets and ConfigMaps associated with the ModelRegistry CR (as described above in [Terms](#terms) are handled by the backend route and performed by the service account. Requests to the backend pass along the database password or certificate information and the underlying resources are abstracted away.)
+- **Usage of Service Account** -- Non-cluster-admin users (including ODH admins) do not have permission to create or view resources in the registries namespace (except Services). Admin operations on the Model Registry Settings page use the dashboard's service account. A BFF (Backend-for-Frontend) layer has been implemented (`packages/model-registry/upstream/bff/` in Go) which provides RBAC via `SelfSubjectRulesReview` and is part of the modular architecture.
+  - The writing and reading of Secrets and ConfigMaps associated with the ModelRegistry CR (as described above in [Terms](#terms)) are handled by the backend and performed by the service account. Requests to the backend pass along the database password or certificate information and the underlying resources are abstracted away.
 
 ### Autofilling Model Locations from Connections
 

--- a/documentation/components/dashboard/features/modelRegistry.md
+++ b/documentation/components/dashboard/features/modelRegistry.md
@@ -1,6 +1,6 @@
 # Model Registry
 
-> Introduced in 2.16 as Tech Preview. Fully implemented with feature flag (`disableModelRegistry`) under tech preview flags.
+> Introduced in 2.16 as Tech Preview and GA'ed in 2.25. Fully implemented with feature flag (`disableModelRegistry`) under tech preview feature flags.
 
 - [Introduction](#introduction)
   - [A Model Registry is a Metadata Service Only](#a-model-registry-is-a-metadata-service-only)

--- a/documentation/components/dashboard/k8sLabelsAndAnnotations.md
+++ b/documentation/components/dashboard/k8sLabelsAndAnnotations.md
@@ -1,4 +1,4 @@
-[AcceleratorProfile]: ./README.md#acceleratorprofiles
+[AcceleratorProfile]: ./README.md#acceleratorprofiles-deprecated
 
 [`openshift.io/display-name`]: #openshiftiodisplay-name
 [`openshift.io/description`]: #openshiftiodescription
@@ -29,8 +29,11 @@ Dashboard has a reputation of using a lot of annotations and labels on various r
   * [ImageStreams](#imagestreams)
   * [Notebooks](#notebooks)
   * [ServingRuntime Templates](#servingruntime-templates)
+  * [InferenceServices](#inferenceservices)
   * [Storage Classes](#storage-classes)
+  * [HardwareProfiles](#hardwareprofiles)
   * [Model Registry](#model-registry)
+  * [Model Catalog](#model-catalog)
 
 ## Common Labels
 
@@ -129,8 +132,9 @@ For the Project Sharing feature specifically:
 * Annotations
   * [`openshift.io/display-name`]
   * [`openshift.io/description`]
-  * `opendatahub.io/connection-type` - Legacy value. Used to identify S3-compatible data connections; `s3` is the only supported value
-  * `opendatahub.io/connection-type-ref` - a reference to the connection type that is used to create the connection
+  * `opendatahub.io/connection-type` - Legacy fallback (pre-2.16). Used to identify S3-compatible data connections; `s3` is the only supported value. Still recognized as a fallback but superseded by `connection-type-ref`.
+  * `opendatahub.io/connection-type-ref` - (2.16+) The primary annotation referencing the connection type schema used to create the connection (e.g., `s3`, `uri-v1`, `oci-v1`)
+  * `opendatahub.io/connection-type-protocol` - (3.0+) Explicitly identifies the connection protocol for webhook validation and routing. Supported values: `s3`, `uri`, `oci`. Takes precedence over `connection-type-ref` when both are present.
 
 ### ImageStreams
 
@@ -156,13 +160,14 @@ These are configured by the admin in the UI and are provided as out-of-the-box e
 > Note: This is a Workbench backed feature.
 
 * Labels
-  * `opendatahub.io/odh-managed` - (unknown, potential legacy without value)
+  * `opendatahub.io/odh-managed` - Set to `'true'` to mark notebooks created and managed by the Dashboard. This label is actively set during notebook creation.
   * `opendatahub.io/user` - a translated username; the Dashboard k8s-ifies the user's username so we can compare or look up by user in the future
 * Annotations
   * [`openshift.io/display-name`]
   * [`openshift.io/description`]
   * `opendatahub.io/username` - the actual username (related to the Label `opendatahub.io/user`)
   * [`opendatahub.io/accelerator-name`]
+  * `opendatahub.io/connections` - a comma-separated list of `<namespace>/<secret-name>` references connecting the workbench to Connection secrets. The namespace prefix allows the system to perform a SubjectAccessReview to verify the user has permission to access the Secret. The connection Secret must be in the same namespace as the Notebook.
   * `opendatahub.io/workbench-image-namespace` - This annotation is used to indicate the scope of a workbench image. If the workbench image is project-scoped, this annotation is added with the workbench image’s namespace. If it’s global-scoped, the annotation is omitted.
   * `opendatahub.io/hardware-profile-namespace` - This annotation is used to indicate the scope of a hardware profile. If the hardware profile is project-scoped, this annotation is added with the hardware profile’s namespace. If it’s global-scoped, the annotation is omitted.
   * `opendatahub.io/accelerator-profile-namespace` - This annotation is used to indicate the scope of a accelerator profile. If the accelerator profile is project-scoped, this annotation is added with the accelerator profile’s namespace. If it’s global-scoped, the annotation is omitted.
@@ -175,7 +180,7 @@ These are configured by the admin in the UI and are provided as out-of-the-box e
 
 * Annotations (when configuring in the admin page)
   * [`openshift.io/display-name`]
-  * `opendatahub.io/modelServingSupport` - (managed by the UI) an JSON Array of supported platforms; options: 'single', 'multi'
+  * `opendatahub.io/modelServingSupport` - (managed by the UI) a JSON array string of supported platforms (e.g., `'["single"]'`); options: `'single'`, `'multi'`. Note: ModelMesh (`'multi'`) is deprecated.
   * `opendatahub.io/apiProtocol` - (managed by the UI) the api protocols available; options (one of): 'REST', 'gRPC' 
   * `opendatahub.io/disable-gpu` - (optional, typed in) if the ServingRuntime should not be used with GPUs (aka accelerators)
   * [`opendatahub.io/recommended-accelerators`] - (optional, typed in)
@@ -188,10 +193,25 @@ These are configured by the admin in the UI and are provided as out-of-the-box e
   * `opendatahub.io/hardware-profile-namespace` -  This annotation is used to indicate the scope of a hardware profile. If the hardware profile is project-scoped, this annotation is added with the hardware profile’s namespace. If it’s global-scoped, the annotation is omitted.
   * `opendatahub.io/accelerator-profile-namespace` - This annotation is used to indicate the scope of a accelerator profile. If the accelerator profile is project-scoped, this annotation is added with the accelerator profile’s namespace. If it’s global-scoped, the annotation is omitted.
 
+### InferenceServices
+
+> Note: This is a Model Serving backed feature.
+
+* Annotations
+  * `opendatahub.io/connections` - a single connection reference (secret name, no namespace prefix needed) connecting the InferenceService to a Connection secret for model storage access. The connection Secret must be in the same namespace as the InferenceService.
+
 ### Storage Classes
 
 * Annotations
   * [`opendatahub.io/sc-config`] - (managed by the UI) a JSON Blob of storage class metadata
+
+### HardwareProfiles
+
+> Note: HardwareProfiles are GA (`hardwareprofiles.infrastructure.opendatahub.io/v1`) and replace the deprecated AcceleratorProfiles CRD.
+
+* Annotations
+  * [`openshift.io/display-name`]
+  * [`openshift.io/description`]
 
 ### Model Registry
 
@@ -201,3 +221,16 @@ These are configured by the admin in the UI and are provided as out-of-the-box e
   * `modelregistry.opendatahub.io/registered-model-id` and `modelregistry.opendatahub.io/model-version-id` - These labels identify InferenceServices deployed via the model registry UI and get the Model Registry Controller to sync the deployment. They are also used to filter InferenceServices when viewing the list of deployments for a specific model version.
 
   * `modelregistry.opendatahub.io/name` - This label provides a unique reference to InferenceServices deployed via a model registry. It ensures that models will be listed in the deployments tab of that specific registry, preventing incorrect listing across multiple registries with overlapping model IDs.  
+
+### Model Catalog
+
+Model catalog data is stored in ConfigMaps in the installation namespace (`opendatahub`):
+
+* ConfigMaps
+  * `model-catalog-sources` - The main managed ConfigMap containing catalog source and model metadata, defined by the dashboard's manifests. This is not editable by users.
+  * `model-catalog-unmanaged-sources` - A secondary editable ConfigMap with an empty `sources` array, used to populate additional sources/models for demonstration purposes.
+* Special Model Labels (within the `labels` array of a catalog model object)
+  * `featured` - The first 4 models with this label appear in the Model Catalog section of the dashboard home page.
+  * `lab-base` - Designates a model as an InstructLab starter model. Shown with special formatting (yellow color, "LAB starter" text) on the overview page.
+  * `lab-teacher` - Designates a model as an InstructLab teacher model. Shown with special formatting (purple color, "LAB teacher" text) on the overview page.
+  * `lab-judge` - Designates a model as an InstructLab judge model. Shown with special formatting (orange color, "LAB judge" text) on the overview page.


### PR DESCRIPTION
## Summary

- Corrects factual errors in dashboard documentation based on verified findings from the odh-dashboard codebase (HardwareProfiles API group/version, deprecated AcceleratorProfiles/notebookSizes/modelServerSizes, SSAR implementation status, enum renames, etc.)
- Adds missing content: new connection annotations (connection-type-ref, connection-type-protocol, connections), InferenceServices/HardwareProfiles/Model Catalog sections in labels doc, LLMInferenceService as connection consumer, annotation-based connection approach for Notebooks and InferenceServices
- Updates component status: Model Registry shipped (removes "soon"), Model Catalog graduated to GA, BFF implemented for Model Registry, supported components list expanded with Model Catalog/Connections/Fine-Tuning

## Files Changed

| File | Changes |
|---|---|
| `README.md` | Supported components list, CRDs section (HardwareProfiles API fix, AcceleratorProfiles deprecation), SSAR status, project filtering |
| `configuringDashboard.md` | StackComponent rename, deprecated size configs, Telemetry entry |
| `dashboardStorage.md` | HardwareProfiles, ServingRuntime clarification, connection annotations |
| `k8sLabelsAndAnnotations.md` | New annotations, odh-managed fix, InferenceServices/HardwareProfiles/Model Catalog sections |
| `features/connections.md` | Annotation-based connections, LLMInferenceService, Data Connections replacement |
| `features/modelCatalog.md` | GA status, BFF API alongside ConfigMap |
| `features/modelRegistry.md` | Status clarification, BFF implemented |
| `features/README.md` | Features list updated |

## Test plan

- [ ] Review each file for accurate markdown rendering
- [ ] Verify internal cross-reference links resolve correctly
- [ ] Confirm deprecated items are clearly marked without removing backward-compatibility context

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Model Registry and Model Catalog marked GA; feature flag and usage notes added
  * AcceleratorProfiles deprecated; HardwareProfiles introduced as GA replacement (replaces notebook/modelServer size fields; cannot be disabled)
  * Connection terminology updated: “Connections” replaces “Data Connections”; annotation-based wiring (opendatahub.io/connections, opendatahub.io/connection-type-ref) with legacy fallback; InferenceService support noted
  * Admin authorization clarified to rely on SSAR/useAccessReview with service-account fallbacks
  * Config fields/enum renamed and deprecated with migration guidance; OpenShift namespace filtering logic clarified
<!-- end of auto-generated comment: release notes by coderabbit.ai -->