### PR TITLE
Adr review skill

### DIFF
--- a/.claude/skills/odh-adr-review/SKILL.md
+++ b/.claude/skills/odh-adr-review/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: odh-adr-review
+description: Review an Open Data Hub Architectural Decision Record (ADR) using a team of seven specialist reviewer subagents and produce a consolidated report as both PDF and PPTX slide deck. Use this skill whenever the user asks to review, critique, audit, or get feedback on an ADR in the opendatahub-io/architecture-decision-records repository — whether the input is a Markdown file, a .docx document, or pasted text. Trigger even if the user does not explicitly say "ADR"; phrases like "review this architecture decision", "critique this design doc", or "run the reviewer panel on this" should also invoke this skill.
+---
+
+# ODH ADR Review Panel
+
+This skill runs a panel of specialist reviewer subagents over an Open Data Hub Architectural Decision Record (ADR) and produces a consolidated report in two formats: a PDF document and a PPTX slide deck.
+
+This is an ODH-specific adaptation of the generic `adr-review` skill. It adds a seventh reviewer focused on ODH ecosystem and downstream impact, injects ODH-specific context into all reviewers, and checks ADRs against the ODH template format.
+
+## Why a panel of agents?
+
+Architecture reviews benefit from multiple independent perspectives. A single reviewer tends to anchor on whichever concern they noticed first and under-weight the others. By running specialists in parallel, each focused on one dimension, we get broader, less-biased coverage — and the synthesis step surfaces tensions between perspectives (e.g. "the cheapest option is also the least reversible") that a single reviewer might flatten.
+
+The seventh reviewer (ODH Ecosystem & Downstream Impact) is unique to this skill. It evaluates whether the ADR is well-situated within the ODH component ecosystem, follows the ODH template, correctly identifies cross-component stakeholders, and considers downstream RHOAI implications.
+
+## Workflow
+
+### Step 1 — Prompt for the ADR location and clarifying context
+
+Always ask the user where the ADR is, even if there's a plausible file in context. Accepted inputs:
+
+- A path to a Markdown file (`.md`, `.markdown`)
+- A path to a Word document (`.docx`)
+- A path to a directory containing multiple ADRs (review each one)
+
+The default location for ADRs in this repository is the `architecture-decision-records/` directory, including its component subdirectories (e.g., `operator/`, `model-serving/`, `eval-hub/`).
+
+If the user provides a `.docx`, extract the text first using the `document-skills:docx` skill or `python-docx`. If they provide Markdown, read it directly.
+
+**Use the AskUserQuestion tool** to gather any clarifying context the reviewers will need. Ask in a single AskUserQuestion call with multiple questions rather than one-at-a-time. Tailor the questions to what is actually unclear after a quick skim of the ADR — don't ask boilerplate. Typical useful questions:
+
+- **Audience & stakes** — "Who is this review for (author self-check, formal arch review, post-incident retro)?" This shapes tone and severity thresholds.
+- **Scope** — "Are there dimensions you want the panel to emphasize or skip?" (e.g., "skip cost, we already costed it elsewhere")
+- **Context not in the doc** — "Is there background the ADR assumes readers already know? Team size, existing stack, regulatory environment?"
+- **Decision status** — "Is this a draft open to changes, or has the decision already been approved and you want a risk audit?"
+- **Known concerns** — "Anything you're already worried about that you want the panel to focus on?"
+- **Downstream impact** — "Does this decision specifically affect RHOAI managed service, self-managed, or both?"
+
+Pass the answers into each reviewer subagent's prompt as a "Review context from the user" block so every reviewer sees the same framing.
+
+### Step 2 — Read, normalize, and check template compliance
+
+Read the file and extract the key sections. Before dispatching reviewers, check the ADR against the ODH template (`ODH-ADR-0000-template.md` in this repository). Specifically verify:
+
+1. **Metadata table** — Date, Scope, Status, Authors, Supersedes, Superseded by, Tickets, Other docs
+2. **Required sections** — What, Why, Goals, Non-Goals, How, Alternatives, Stakeholder Impacts, Reviews
+3. **Optional but recommended** — Open Questions, Security and Privacy Considerations, Risks, References
+4. **Numbering** — Does the ADR number follow the ODH-ADR-NNNN or ODH-ADR-Component-NNNN pattern?
+
+Note any missing or empty sections. These observations feed into the reviewers (especially the ODH Ecosystem reviewer) as factual input, not as a verdict — a thin ADR may still represent a sound decision.
+
+ADRs vary in adherence to the template. Don't refuse to review a non-conforming ADR; just note the gaps.
+
+### Step 3 — Read ODH review context and dispatch the reviewer panel
+
+First, read the ODH ecosystem context from `references/odh_review_context.md`. This context must be included in every reviewer's prompt.
+
+Then spawn **seven reviewer subagents in parallel** using the Agent tool. Each gets:
+- The full ADR text
+- The ODH review context
+- The template compliance observations from Step 2
+- Its role-specific prompt from `references/reviewer_prompts.md`
+- The "Review context from the user" block from Step 1
+
+Launch all seven in a single message — do not serialize them.
+
+The seven reviewers are:
+
+1. **Context & Problem Framing** — Is the problem and its forces clearly articulated? Are the stakeholders and constraints named? Were alternatives genuinely considered?
+2. **Technical Soundness** — Is the proposed solution technically correct and feasible? Does it match the problem? Does it work within the OpenShift/ODH platform?
+3. **Operational & Reliability** — How will this be observed, deployed, and recovered? What are the failure modes in production? Does it consider managed service SLAs?
+4. **Security & Compliance** — Threat model, data handling, authN/authZ, secrets, regulatory implications. Does it maintain namespace isolation?
+5. **Cost & Performance** — Resource footprint, cost trajectory, latency/throughput, capacity planning within ODH's resource model.
+6. **Consequences & Reversibility** — Are the trade-offs honestly stated? How hard is this to undo? Does it constrain future ODH/RHOAI releases?
+7. **ODH Ecosystem & Downstream Impact** — Template compliance, cross-component impact, upstream/downstream alignment, operator integration, consistency with existing ADRs.
+
+Each reviewer must return a structured finding in this shape:
+
+```markdown
+## [Reviewer Name]
+**Overall assessment:** [Strong / Acceptable / Concerns / Blocking]
+**Strengths:** [bullets]
+**Concerns:** [bullets, each with the structure below]
+**Open questions:** [bullets]
+**Recommendations:** [bullets]
+```
+
+Each concern must include enough detail for an architect unfamiliar with the review to understand the issue and act on it. Use this structure per concern:
+
+```markdown
+- **[severity: low / med / high] [Short title]**
+  _What:_ One or two sentences describing the specific gap or problem found in the ADR.
+  _So what:_ Why this matters — the concrete consequence if the ADR is accepted without addressing it (e.g., implementer confusion, production risk, blocked downstream ADR).
+  _Suggested fix:_ What the author should add, change, or clarify in the document to resolve it. Be specific enough that the author can act without re-reading the full review.
+```
+
+This level of detail applies to both the **PDF report** and **Step 3.5** (human-in-the-loop review). The user needs the full _What / So what / Suggested fix_ context to make informed agree/disagree decisions. Only the **PPTX** should use short-form bullets (title + severity) to stay scannable for meetings.
+
+### Step 3.5 — Human-in-the-loop review of findings
+
+Before synthesizing or generating any report, walk the user through the reviewers' findings and let them correct the record. This step exists because the reviewers are operating with limited context — the user often knows things (prior decisions, team dynamics, constraints that didn't make it into the doc) that would change whether a finding is valid.
+
+Present the findings grouped by reviewer. For each reviewer, show:
+
+- The overall assessment
+- Each concern and recommendation as a discrete item
+
+Then use the **AskUserQuestion tool** to collect the user's agree/disagree judgment. Batch the questions — don't spam one call per concern. A reasonable approach:
+
+- One AskUserQuestion call per reviewer (7 total), with one question per non-trivial concern, offering options like "Agree", "Disagree — not a real issue", "Partially agree — needs rewording", "Already addressed elsewhere". Include a free-text option so the user can explain.
+- Skip questions for concerns that are clearly low-severity and uncontroversial — respect the user's time.
+
+Apply the user's corrections to the findings before synthesis:
+
+- **Disagreed** concerns: remove them, and note in a "Reviewer corrections" sidebar that the user overrode the finding (with their reason if given). Keeping the audit trail matters — a disagreement is data, not an eraser.
+- **Partially agreed** concerns: rewrite per the user's guidance.
+- **Already addressed** concerns: move them to an "Addressed elsewhere" section rather than deleting, so reviewers of the report understand why they're absent.
+
+The corrected findings — not the raw ones — are what feed into synthesis.
+
+### Step 4 — Synthesize
+
+Once all seven reviewers return, synthesize their findings into an overall report. The synthesis is not just concatenation — look for:
+
+- **Agreements** — where multiple reviewers raised the same concern (stronger signal)
+- **Tensions** — where reviewers disagree or where one dimension's "win" is another's "loss"
+- **Gaps** — dimensions where nobody found much to say (may indicate the ADR didn't address it at all)
+- **Top risks** — the 3-5 highest-severity items across the panel
+- **Template compliance** — summarize how well the ADR adheres to the ODH template (from the Ecosystem reviewer's findings)
+- **Downstream readiness** — is this ADR ready for RHOAI productization, or are there open concerns?
+- **Overall recommendation** — Approve / Approve with changes / Needs revision / Reject, with a one-paragraph rationale
+
+### Step 5 — Generate PDF and PPTX reports
+
+Create a `adr-review/` subdirectory next to the input ADR file. Write outputs there:
+
+- `adr-review/<adr-name>-review.pdf`
+- `adr-review/<adr-name>-review.pptx`
+
+**PDF structure** — use the `document-skills:pdf` skill (or `reportlab` directly if the skill isn't available):
+
+1. Title page — ADR name, date of review, overall recommendation
+2. Executive summary — 3-5 bullets, top risks, overall recommendation, template compliance summary
+3. One section per reviewer with their full finding. Each concern must include the verbose _What / So what / Suggested fix_ detail so a reader can understand consequences and act on the finding without external context.
+4. Synthesis section — agreements, tensions, gaps, downstream readiness
+
+The PDF is the detailed, self-contained artifact. Err on the side of too much context per concern rather than too little — the reader may not have been in the review conversation.
+
+**PPTX structure** — use the `document-skills:pptx` skill (or `python-pptx` directly if the skill isn't available). Follow the styling rules in `references/report_templates.md` (color palette, typography, slide layout) to produce a clean, professional deck — not plain white slides with default fonts:
+
+1. Title slide — dark background, ADR name, date, verdict badge
+2. Executive summary (overall assessment + top 3 risks)
+3. One slide per reviewer (verdict badge + top 2 concerns with severity colors + top recommendation) — 7 slides total
+4. Synthesis slide (agreements / tensions / gaps)
+5. Next steps / recommendation slide
+
+Keep slides scannable — bullets, not paragraphs. The PDF is the detailed artifact; the deck is for a 10-minute review meeting.
+
+### Step 6 — Report back
+
+Tell the user where the outputs landed and give a brief summary (overall recommendation + top risks + template compliance) inline so they don't have to open the files to get the gist.
+
+## Handling edge cases
+
+- **Directory of ADRs** — run the full workflow on each ADR and produce per-ADR outputs. Offer a roll-up report at the end if there are more than three.
+- **Very short ADRs** — still run the full panel. A too-thin ADR is itself a finding (the Context & Framing reviewer and ODH Ecosystem reviewer will flag it).
+- **Missing sections** — don't refuse to review. Note the gap and continue.
+- **Non-ODH ADR format** (e.g., MADR, Nygard) — proceed anyway; the panel works on any architecture writeup. The Ecosystem reviewer will note that the ODH template wasn't followed.
+- **ADRs in component subdirectories** — these are normal. The numbering pattern may be ODH-ADR-Component-NNNN rather than ODH-ADR-NNNN.
+
+## Reference files
+
+- `references/reviewer_prompts.md` — The full role prompt for each of the seven reviewer subagents. Read this when dispatching the panel.
+- `references/odh_review_context.md` — ODH ecosystem context injected into every reviewer's prompt. Read this before dispatching.
+- `references/report_templates.md` — PDF and PPTX structure templates with example content and styling rules.

--- a/.claude/skills/odh-adr-review/SKILL.md
+++ b/.claude/skills/odh-adr-review/SKILL.md
@@ -7,7 +7,7 @@ description: Review an Open Data Hub Architectural Decision Record (ADR) using a
 
 This skill runs a panel of specialist reviewer subagents over an Open Data Hub Architectural Decision Record (ADR) and produces a consolidated report in two formats: a PDF document and a PPTX slide deck.
 
-This is an ODH-specific adaptation of the generic `adr-review` skill. It adds a seventh reviewer focused on ODH ecosystem and downstream impact, injects ODH-specific context into all reviewers, and checks ADRs against the ODH template format.
+This is an ODH-specific adaptation of the generic [`adr-review`](https://github.com/opendatahub-io/ai-helpers/tree/main/helpers/skills/adr-review) skill. It adds a seventh reviewer focused on ODH ecosystem and downstream impact, injects ODH-specific context into all reviewers, and checks ADRs against the ODH template format.
 
 ## Why a panel of agents?
 

--- a/.claude/skills/odh-adr-review/references/odh_review_context.md
+++ b/.claude/skills/odh-adr-review/references/odh_review_context.md
@@ -1,0 +1,84 @@
+# Open Data Hub — Review Context
+
+This document provides ODH-specific context that every reviewer must read before evaluating an ADR in this repository. It supplements each reviewer's domain-specific lens with knowledge of the ODH ecosystem, conventions, and constraints.
+
+## What is Open Data Hub?
+
+Open Data Hub (ODH) is an open-source AI/ML platform built on OpenShift. It is the upstream project for **Red Hat OpenShift AI (RHOAI)**, a commercially supported product. Architectural decisions made in ODH directly affect RHOAI downstream.
+
+## ODH Component Ecosystem
+
+ADRs in this repo may affect one or more of these components:
+
+| Component | Purpose | Key Repos |
+|-----------|---------|-----------|
+| **ODH Operator** | Meta-operator that deploys and manages all components via `DataScienceCluster` CRD | opendatahub-io/opendatahub-operator |
+| **Dashboard** | Unified web UI for all ODH features | opendatahub-io/odh-dashboard |
+| **Workbenches / Notebooks** | JupyterLab-based data science IDEs (Kubeflow Notebook Controller + ODH Notebook Controller) | opendatahub-io/notebooks, opendatahub-io/kubeflow |
+| **Model Serving** | KServe (single-model) and ModelMesh (multi-model) inference serving | opendatahub-io/kserve, opendatahub-io/modelmesh-serving |
+| **Data Science Pipelines** | ML pipeline orchestration (based on Kubeflow Pipelines) | opendatahub-io/data-science-pipelines-operator |
+| **Distributed Workloads** | Ray, CodeFlare, Kueue for distributed training and compute | opendatahub-io/distributed-workloads |
+| **Model Registry** | Model metadata and version tracking | opendatahub-io/model-registry |
+| **TrustyAI / Explainability** | Fairness metrics and model explainability | trustyai-explainability/trustyai-explainability |
+| **Feature Store** | Feast-based feature management for training and serving | opendatahub-io/feast |
+
+## Platform Assumptions
+
+- **OpenShift, not vanilla Kubernetes.** ODH runs on OpenShift Container Platform (OCP), OpenShift Dedicated (OSD), and ROSA. Platform features like Routes, ServiceMesh, Serverless (Knative), OLM, and OpenShift authentication are available and commonly used.
+- **Operator Lifecycle Manager (OLM)** manages operator installation and upgrades.
+- **Namespace-based multi-tenancy with Kubernetes RBAC** is the standard isolation model. ODH does not use Kubeflow Profiles, Istio-based auth, or Dex for multi-user isolation.
+- **CRD-driven API.** The `DataScienceCluster` CRD is the primary API surface. New components must integrate with the operator and expose configuration through this CRD.
+
+## Upstream / Downstream Relationship
+
+- **ODH is upstream; RHOAI is downstream.** Changes to ODH are synced to downstream Red Hat repositories (red-hat-data-services/*) for productization.
+- **Kubeflow is further upstream** for several components (Notebooks, Pipelines). ODH forks and extends Kubeflow components. Decisions that diverge from upstream Kubeflow should justify the divergence and consider the ongoing rebase cost.
+- ADRs should consider: *Can this decision be synced downstream to RHOAI without breaking the productization flow?*
+
+## Release Cadence
+
+RHOAI follows a 3-month release cycle:
+- **EA1 (Early Access 1):** ~1 month after development begins
+- **EA2 (Early Access 2):** ~1 month after EA1
+- **GA (General Availability):** ~1 month after EA2
+
+ADRs do not need to be implementable within a single release phase, but should be aware of this cadence when discussing rollout strategy.
+
+## Cross-Component Dependencies
+
+Decisions in one component frequently affect others. Common patterns:
+- Model Serving changes often require Dashboard UI updates, Operator CRD changes, and ServiceMesh/Serverless configuration
+- Pipeline changes may affect Workbench integrations
+- Operator-level decisions (CRD schema, lifecycle management) affect all components
+- Security and authentication changes ripple across Dashboard, Notebooks, and Model Serving
+
+The **Stakeholder Impacts** table in the ODH template exists to capture these cross-component effects. Reviewers should flag when this table appears incomplete given the scope of the decision.
+
+## ODH ADR Template Format
+
+ADRs in this repository follow the template in `ODH-ADR-0000-template.md`. The expected sections are:
+
+| Section | Required? | Notes |
+|---------|-----------|-------|
+| Metadata table (Date, Scope, Status, Authors, Supersedes, Tickets, Other docs) | Yes | Status should be "Approved" when merged |
+| What | Yes | Brief description of the decision |
+| Why | Yes | Motivation — why an ADR is needed |
+| Goals | Yes | Bulleted list |
+| Non-Goals | Yes | Bulleted list — what is explicitly out of scope |
+| How | Yes | High-level approach |
+| Open Questions | Optional | Should be resolved before status moves to Approved |
+| Alternatives | Yes | Must document trade-offs of each option |
+| Security and Privacy Considerations | Optional | But strongly encouraged |
+| Risks | Optional | But strongly encouraged |
+| Stakeholder Impacts | Yes | Table with Group, Key Contacts, Date, Impacted? |
+| References | Optional | Supporting links |
+| Reviews | Yes | Table tracking reviewer sign-offs |
+
+This format differs from MADR and Nygard-style ADRs. Reviewers should evaluate completeness against this template, not against other ADR formats.
+
+## ADR Governance
+
+- ADRs are numbered sequentially (ODH-ADR-NNNN or ODH-ADR-Component-NNNN). Numbers are not reused.
+- Superseded ADRs remain in the repo, marked with `Superseded by` in the metadata table.
+- Component-scoped ADRs live in subdirectories (e.g., `operator/`, `model-serving/`, `eval-hub/`).
+- ADRs are approved by merging the PR after collecting reviewer sign-offs in the Reviews table.

--- a/.claude/skills/odh-adr-review/references/odh_review_context.md
+++ b/.claude/skills/odh-adr-review/references/odh_review_context.md
@@ -20,7 +20,15 @@ ADRs in this repo may affect one or more of these components:
 | **Distributed Workloads** | Ray, CodeFlare, Kueue for distributed training and compute | opendatahub-io/distributed-workloads |
 | **Model Registry** | Model metadata and version tracking | opendatahub-io/model-registry |
 | **TrustyAI / Explainability** | Fairness metrics and model explainability | trustyai-explainability/trustyai-explainability |
+| **EvalHub** | Unified evaluation service for orchestrating AI model evaluations across multiple frameworks (lm_evaluation_harness, ragas, garak, etc.). Managed by the TrustyAI operator. | opendatahub-io/eval-hub |
+| **AutoML** | Automated ML model building and optimization for tabular data using AutoGluon, orchestrated via Kubeflow Pipelines. Integrates with Model Registry and KServe. | opendatahub-io/automl |
+| **AutoRAG** | Automated RAG application optimization using ai4rag engine, orchestrated via Kubeflow Pipelines. Explores chunking, embedding, retrieval, and generation configurations. | opendatahub-io/autorag |
+| **RAG and Vector DB** | Document ingestion, chunking, embedding, and vector database management for retrieval-augmented generation workflows. Provides the runtime infrastructure that AutoRAG optimizes against. |
+| **Llama Stack** | LLM inference API layer providing unified access to language models and vector databases for AI workloads | opendatahub-io/llama-stack |
 | **Feature Store** | Feast-based feature management for training and serving | opendatahub-io/feast |
+| **Agent Ops** | Onboards agents and MCP servers to the platform. Facilitates configuration of sandboxes, workload identity using SPIFFE/SPIRE, credential management, authorization, and agent discovery. Implemented using OpenShell, Agent Operator, MCP Operator, Agent Sandbox, and MCP Gateway.
+| **Model and Agent Observability** | Collects traces and metadata about models and agents. Visualizes traces, creates evaluation datasets, evaluates expected vs. actual behavior.  Uses MLflow.
+| **Model as a Service** | Platform-managed LLM inference endpoints that provide shared, pre-deployed models to users without requiring them to provision their own model serving infrastructure. |
 
 ## Platform Assumptions
 

--- a/.claude/skills/odh-adr-review/references/report_templates.md
+++ b/.claude/skills/odh-adr-review/references/report_templates.md
@@ -1,0 +1,157 @@
+# Report Templates
+
+## PDF Template
+
+```text
+[TITLE PAGE]
+  ADR Review: <ADR title>
+  Reviewed: <date>
+  Overall Recommendation: <Approve | Approve with changes | Needs revision | Reject>
+
+[EXECUTIVE SUMMARY]
+  - Overall assessment (1 sentence)
+  - Template compliance: <Fully compliant | Minor gaps | Significant gaps> (1 sentence)
+  - Top 3-5 risks (each with severity)
+  - Downstream readiness: <Ready | Needs work | Blocking issues>
+  - Recommended next steps (3 bullets)
+
+[REVIEWER FINDINGS]
+  For each of the seven reviewers:
+    ## <Reviewer Name>
+    Overall: <Strong | Acceptable | Concerns | Blocking>
+    Strengths: ...
+    Concerns:
+      For each concern:
+        [severity: low / med / high] Short title
+        What: specific gap or problem in the ADR (1-2 sentences)
+        So what: concrete consequence if unaddressed (implementer confusion, production risk, etc.)
+        Suggested fix: what the author should add/change/clarify to resolve it
+    Open questions: ...
+    Recommendations: ...
+
+[SYNTHESIS]
+  Agreements across reviewers:
+  Tensions between dimensions:
+  Gaps (dimensions the ADR didn't address):
+  Template compliance summary:
+  Downstream readiness assessment:
+  Top risks (consolidated):
+  Overall recommendation with rationale:
+```
+
+## PPTX Template
+
+Slide 1 — Title
+  - ADR name
+  - Review date
+  - Overall recommendation badge
+
+Slide 2 — Executive Summary
+  - Overall assessment (1 line)
+  - Top 3 risks
+  - Template compliance (1 line)
+  - Recommendation
+
+Slides 3-9 — One per Reviewer
+  - Reviewer name as title
+  - Assessment (Strong/Acceptable/Concerns/Blocking)
+  - Top 2 concerns
+  - Top recommendation
+
+Slide 10 — Synthesis
+  - Where reviewers agreed
+  - Where they disagreed
+  - What nobody covered (gaps)
+
+Slide 11 — Next Steps
+  - Overall recommendation
+  - 3-5 action items
+  - Open questions to resolve before proceeding
+
+## PPTX styling
+
+When generating the PPTX with `python-pptx`, apply these styling rules to produce
+a clean, professional deck rather than plain white slides with default fonts.
+
+### Color palette (RGB hex)
+
+| Role | Hex | Usage |
+|------|-----|-------|
+| Dark background | #1B2A4A | Title slide background, section headers |
+| White text | #FFFFFF | Text on dark backgrounds |
+| Light grey bg | #F4F5F7 | Content slide backgrounds |
+| Dark text | #2D3748 | Body text on light backgrounds |
+| Muted text | #718096 | Subtitles, metadata, dates |
+| Accent blue | #3182CE | Section title underlines, key labels |
+| Severity red | #C53030 | [high] severity tags |
+| Severity amber | #C05621 | [med] severity tags |
+| Severity grey | #718096 | [low] severity tags |
+| Strong/Approve | #276749 | Strong/Approve verdict badges |
+| Acceptable | #2B6CB0 | Acceptable verdict badges |
+| Concerns | #C05621 | Concerns verdict badges |
+| Blocking/Reject | #C53030 | Blocking/Reject verdict badges |
+
+### Typography
+
+| Element | Font | Size | Weight | Color |
+|---------|------|------|--------|-------|
+| Title slide heading | Calibri | 36pt | Bold | White |
+| Title slide subtitle | Calibri | 20pt | Normal | #A0AEC0 |
+| Slide title | Calibri | 26pt | Bold | #1B2A4A |
+| Slide subtitle | Calibri | 14pt | Normal | #718096 |
+| Bullet text | Calibri | 16pt | Normal | #2D3748 |
+| Severity tag | Calibri | 16pt | Bold | per severity color |
+| Verdict badge | Calibri | 14pt | Bold | per verdict color |
+
+### Slide layout rules
+
+- **Slide size:** 13.333 x 7.5 inches (widescreen 16:9).
+- **Title slide:** Dark background (#1B2A4A). Title centered vertically in upper third. Subtitle (ADR name) below. Date and verdict in lower third, muted.
+- **Content slides:** Light grey background (#F4F5F7). Slide title in top-left at (0.8in, 0.5in) with width 11.5in. A thin accent line (2pt, #3182CE) below the title at ~1.15in from top. Body content starts at 1.4in from top with 0.8in left margin.
+- **Verdict badges on reviewer slides:** Show the verdict (Strong/Acceptable/Concerns/Blocking) as colored text next to or below the reviewer name, using the verdict color.
+- **Severity tags:** When listing concerns, prefix with [high], [med], or [low] in the matching severity color. The rest of the bullet text stays in dark text color.
+- **Max 5 bullets per slide, max ~12 words per bullet.** If a reviewer has more than 2 high/med concerns, pick the top 2.
+- **Synthesis and Next Steps slides** use the same content-slide layout.
+- **No clip art, no stock images, no logos.** Clean typography only.
+
+### python-pptx implementation notes
+
+To set a slide background color:
+
+```python
+from pptx.oxml.ns import qn
+bg = slide.background
+fill = bg.fill
+fill.solid()
+fill.fore_color.rgb = RGBColor(0x1B, 0x2A, 0x4A)
+```
+
+To add a thin accent line below the title:
+
+```python
+from pptx.util import Inches, Pt, Emu
+line = slide.shapes.add_shape(
+    MSO_SHAPE.RECTANGLE, Inches(0.8), Inches(1.15), Inches(11.5), Pt(2)
+)
+line.fill.solid()
+line.fill.fore_color.rgb = RGBColor(0x31, 0x82, 0xCE)
+line.line.fill.background()  # no border on the shape
+```
+
+To apply a font with color to a run:
+
+```python
+run = paragraph.add_run()
+run.text = "[high]"
+run.font.size = Pt(16)
+run.font.bold = True
+run.font.color.rgb = RGBColor(0xC5, 0x30, 0x30)
+run.font.name = "Calibri"
+```
+
+## Style notes
+
+- PDF is the detailed artifact; preserve full reviewer text including _What / So what / Suggested fix_ for every concern. A reader should be able to understand consequences and act on findings without external context.
+- Slides are for a meeting — bullets, not paragraphs. Max 5 bullets/slide, max ~12 words/bullet.
+- Use severity color cues where possible (red = high, amber = med, grey = low).
+- Keep the title slide and exec summary self-contained — someone should be able to get the bottom line from those two alone.

--- a/.claude/skills/odh-adr-review/references/reviewer_prompts.md
+++ b/.claude/skills/odh-adr-review/references/reviewer_prompts.md
@@ -1,0 +1,174 @@
+# Reviewer Panel Prompts
+
+Each reviewer gets the full ADR text, the ODH review context from `references/odh_review_context.md`, and their role prompt below. All reviewers must return findings in the structured format specified in SKILL.md (Overall assessment / Strengths / Concerns / Open questions / Recommendations).
+
+Reviewers should stay in their lane — if the Security reviewer notices a cost issue, they can mention it briefly but should not lead with it. The synthesis step catches cross-cutting concerns.
+
+When reviewing, keep the ODH ecosystem context in mind. The ADR is being written for Open Data Hub and may affect downstream RHOAI. Consider the OpenShift platform, the operator-driven architecture, and the cross-component dependencies described in the ODH review context.
+
+---
+
+## 1. Context & Problem Framing
+
+You are reviewing an Architectural Decision Record focused on whether the **problem and its forces** are clearly articulated. You are not evaluating the solution itself — leave that to other reviewers.
+
+Evaluate:
+- Is the problem statement specific and concrete, or vague?
+- Are the driving forces (constraints, requirements, non-functionals) named?
+- Are stakeholders and their needs identified?
+- Were alternatives genuinely considered, or does this read as post-hoc rationalization for a decision already made?
+- Is the "why now" clear? What changed to make this decision necessary?
+
+ODH-specific considerations:
+- Does the ADR identify which ODH component(s) are in scope?
+- Is the Scope field in the metadata table filled in and accurate?
+- Does the "Why" section explain the motivation clearly, not just restate the "What"?
+- Are the Goals and Non-Goals sections present and meaningful, or just boilerplate?
+
+Red flags: no alternatives listed; only one option evaluated seriously; forces that appear only after the decision; missing context about the existing system; Scope field is blank or vague.
+
+---
+
+## 2. Technical Soundness
+
+You are reviewing the **technical correctness and feasibility** of the proposed solution. Assume the problem framing is accurate and focus on whether the chosen approach will actually work.
+
+Evaluate:
+- Does the solution match the problem? Are there obvious mismatches in scale, paradigm, or capability?
+- Are there known anti-patterns or failure modes this approach is prone to?
+- Are the technical claims backed by evidence (benchmarks, prior art, prototypes)?
+- Are the integration points realistic? Dependencies available and stable?
+- Does this fight the grain of the existing stack, or work with it?
+
+ODH-specific considerations:
+- Does the solution work within the OpenShift platform (not just vanilla Kubernetes)?
+- If the ADR introduces a new dependency, is it available in the restricted/disconnected environments where ODH/RHOAI may be deployed?
+- Does the approach align with how the ODH Operator manages components (CRD-driven, manifest-based)?
+- If this touches Kubeflow-originated components, does it diverge from upstream in ways that make rebasing difficult?
+
+Red flags: hand-wavy performance claims; unproven technology for critical path; reinventing well-solved problems; tight coupling to unstable deps; solutions that assume internet access in disconnected environments.
+
+---
+
+## 3. Operational & Reliability
+
+You are reviewing how this decision will play out in **production operations**. Assume the technical design is sound and ask: what happens when it's running at 3am?
+
+Evaluate:
+- Observability: metrics, logs, traces, alerts. Can on-call diagnose issues?
+- Deployment: rollout strategy, canary/blue-green, feature flags?
+- Failure modes: what breaks, how does it degrade, what's the blast radius?
+- Rollback: if this decision turns out wrong, can we back it out? How painful?
+- SLOs and capacity: are targets stated? Is there a capacity model?
+- On-call burden: does this make life harder for whoever carries the pager?
+
+ODH-specific considerations:
+- RHOAI is offered as a managed service (on OSD/ROSA) with SLAs. Will this decision affect SRE paging and incident response?
+- Does the operator handle upgrades and rollbacks for this component, or is manual intervention needed?
+- Are Prometheus metrics exposed for the monitoring stack?
+- Does the ADR consider both self-managed (on-prem OCP) and managed service deployment contexts?
+
+Red flags: no observability story; no rollback plan; single points of failure; unclear ownership; changes that would increase SRE paging without acknowledgment.
+
+---
+
+## 4. Security & Compliance
+
+You are reviewing the **security posture and compliance implications**. Assume the design works; ask what it exposes.
+
+Evaluate:
+- Threat model: what new attack surface does this add? Who are the relevant adversaries?
+- Data handling: what data flows through this, at what sensitivity? Is it encrypted in transit and at rest?
+- AuthN/AuthZ: who can access what? Principle of least privilege applied?
+- Secrets: how are credentials managed? Any risk of leakage?
+- Regulatory: GDPR, HIPAA, SOC2, PCI — anything that applies here?
+- Supply chain: new dependencies, their provenance and update cadence?
+
+ODH-specific considerations:
+- Authentication flows through OpenShift's auth service (oauth-proxy sidecars). Does this decision maintain or bypass that pattern?
+- Multi-tenancy is namespace-based with K8s RBAC. Does this decision respect namespace isolation boundaries?
+- RHOAI customers may operate in regulated environments (FedRAMP, HIPAA). Does the "Security and Privacy Considerations" section address this?
+- If new container images are introduced, what registries are they pulled from? Is there a disconnected/air-gapped story?
+- Does the ADR address secrets management (OpenShift Secrets, not environment variables)?
+
+Red flags: no mention of auth; secrets in config; no data classification; net-new externally-exposed surface without security review; assumptions that bypass namespace isolation.
+
+---
+
+## 5. Cost & Performance
+
+You are reviewing the **economic and performance implications** at current and projected scale.
+
+Evaluate:
+- Resource footprint: CPU, memory, storage, network, specialized hardware (GPUs)?
+- Cost trajectory: linear with usage? Step functions? Fixed overhead?
+- Performance characteristics: latency, throughput, tail behavior?
+- Capacity planning: how does this scale? Where are the cliffs?
+- Comparison: is this noticeably more or less expensive than alternatives?
+- Hidden costs: egress, licensing, ops burden, lock-in premiums.
+
+ODH-specific considerations:
+- RHOAI has documented default resource limits for each component (see arch-overview.md). Does this decision stay within reasonable bounds, or significantly increase the cluster footprint?
+- RHOAI supports consumption-based billing. Does this change affect how usage is metered?
+- GPU resources are expensive and shared. If this decision involves GPU workloads, is the resource allocation well-bounded?
+- Does the decision affect the Kueue-based job scheduling or Ray-based distributed compute resource model?
+
+Red flags: no cost discussion at all; performance claims without numbers; usage-based pricing with no cap; assumptions that don't survive 10x growth; new components with no resource limits specified.
+
+---
+
+## 6. Consequences & Reversibility
+
+You are reviewing whether the **trade-offs are honestly stated** and how hard this decision will be to unwind if it turns out wrong.
+
+Evaluate:
+- Are the negative consequences named, not just the positive ones?
+- Lock-in: vendor, technology, data format, team skills?
+- Reversibility: if in 18 months we decide this was wrong, what's the exit cost?
+- Migration path: is there a plausible story for moving off this in the future?
+- Downstream effects: what does this constrain for future decisions?
+- Knowledge/skill requirements: does this demand expertise the team doesn't have?
+
+ODH-specific considerations:
+- Does this decision constrain future ODH releases or RHOAI productization?
+- If a CRD schema is changed, is there a migration path for existing clusters? CRD changes are hard to reverse once deployed to customer clusters.
+- Does the decision lock ODH further away from upstream Kubeflow in a way that increases long-term rebase cost?
+- Would reversing this decision require a coordinated change across multiple ODH components?
+
+Red flags: all-upside framing; no mention of what we're giving up; "we can always migrate later" without a plan; decisions that silently constrain many future decisions; CRD changes with no migration strategy.
+
+---
+
+## 7. ODH Ecosystem & Downstream Impact
+
+You are reviewing whether this ADR is **well-situated within the ODH ecosystem** and whether its cross-cutting effects have been adequately identified. The other six reviewers evaluate the decision on its own merits; your job is to evaluate it in context.
+
+Evaluate:
+
+### Template & Process Compliance
+- Does the ADR follow the ODH template (`ODH-ADR-0000-template.md`)? Are required sections present?
+- Is the metadata table complete (Date, Scope, Status, Authors, Supersedes, Tickets)?
+- Is the numbering correct and consistent with the existing ADR series?
+- Are Open Questions resolved if the Status is Approved?
+
+### Cross-Component Impact
+- Does the Stakeholder Impacts table identify all affected ODH components?
+- Are the right teams and contacts listed? (Cross-reference with the component list in the ODH review context.)
+- Does the decision introduce new dependencies between components that aren't captured?
+- Could this decision break or require changes in the Dashboard, Operator, or other components that aren't mentioned?
+
+### Upstream / Downstream Alignment
+- If this touches Kubeflow-originated code, how far does it diverge from upstream? Is the divergence justified and the rebase cost acknowledged?
+- Can this decision be synced to the RHOAI downstream repositories without friction?
+- Does the decision affect the managed service (OSD/ROSA) differently than self-managed (on-prem OCP)?
+
+### Operator Integration
+- If this introduces or modifies a component, does it describe how it integrates with the `DataScienceCluster` CRD?
+- Are manifest changes needed in the operator? Is the component team aware?
+- Does the ADR reference the component integration requirements?
+
+### Consistency with Existing ADRs
+- Does this decision conflict with or supersede any existing ADRs in this repository? If so, is the relationship documented in the Supersedes/Superseded by fields?
+- Does this decision align with established patterns (namespace isolation, operator-managed lifecycle, CRD-based config)?
+
+Red flags: empty Stakeholder Impacts table; no mention of RHOAI downstream; decisions that clearly affect multiple components but only name one; conflicts with existing ADRs that aren't acknowledged; new components with no operator integration story.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Create a new ADR reviewing skill.  By embedding the skill into the repository, anyone opening it in a Claude Code-compatible coding assistant will automatically have the skill available when they open the repo.

You can test the skill by starting up Cursor and opening the architecture-decision-records folder.  Or, start up Claude Code in with architecture-decision-records as its working directory.  Then prompt the assistant to help you review an ADR. My experience has been that these skills work somewhat better in Claude Code than in Cursor.  For some reason the results from Claude Opus are just better from the CLI.

## How Has This Been Tested?
Tested using Claude Code and Cursor.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated architectural review workflow for Open Data Hub ADRs with a seven-reviewer panel system.
  * Added ODH template compliance validation against repository standards.
  * Enabled human-in-the-loop correction phase where users review and adjust findings before final report generation.
  * Automated multi-format report generation (detailed PDF and scannable PPTX presentations) with structured findings and synthesis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->